### PR TITLE
Populate `pipeline` crate [ch985]

### DIFF
--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -7,3 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+url = { version = "2.1", features = ["serde"] }
+
+[dev-dependencies]
+serde_yaml = "0.8.11"

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -1,7 +1,100 @@
+pub mod node;
+pub mod node_properties;
+pub mod pad;
+pub mod pipeline;
+pub mod resolution;
+
+pub use node::*;
+pub use node_properties::*;
+pub use pad::*;
+pub use pipeline::*;
+pub use resolution::*;
+
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+    use url::Url;
+
+    use crate::{EncodeProperties, StreamRtspOutProperties, UsbCameraProperties};
+    use crate::{NodeProperties, Pipeline, Resolution};
+
     #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+    fn pipeline_nodes_de() {
+        let yaml = r#"---
+- type: usb_camera
+  id: camera1
+  properties:
+    uri: file:///dev/video0
+    framerate: '15'
+    resolution: 720x480
+  wires:
+    video:
+      - encode1.input
+    snapshot: []
+- type: encode
+  id: encode1
+  properties:
+    codec: 'h264'
+    max_bitrate: '1500000'
+    quality: '10'
+    fps: '15'
+  wires:
+    output:
+      - stream_rtsp_out1.input
+- type: stream_rtsp_out
+  id: stream_rtsp_out1
+  properties:
+    uri: rtsp://127.0.0.1:5555/mycamera
+    udp_port: '5800'
+  wires: {}"#;
+
+        let pipeline: Pipeline = serde_yaml::from_str(yaml).unwrap();
+
+        // Check usb_camera node
+        let node = pipeline.node_by_id("camera1").unwrap();
+        assert_eq!(node.id(), "camera1");
+        assert_eq!(
+            node.properties(),
+            &NodeProperties::UsbCamera(UsbCameraProperties {
+                uri: url::Url::from_str("file:///dev/video0").unwrap(),
+                framerate: Some(15),
+                resolution: Some(Resolution {
+                    width: 720,
+                    height: 480
+                })
+            })
+        );
+        let src_pad = node.source_pads().get("snapshot").unwrap();
+        assert!(src_pad.sinks.is_empty());
+        let src_pad = node.source_pads().get("video").unwrap();
+        assert_eq!(src_pad.sinks, &["encode1.input".parse().unwrap()]);
+
+        // Check encode1 node
+        let node = pipeline.node_by_id("encode1").unwrap();
+        assert_eq!(node.id(), "encode1");
+        assert_eq!(
+            node.properties(),
+            &NodeProperties::Encode(EncodeProperties {
+                codec: "h264".to_string(),
+                max_bitrate: Some(1_500_000),
+                bitrate: None,
+                quality: Some(10),
+                fps: Some(15)
+            }),
+        );
+        let src_pad = node.source_pads().get("output").unwrap();
+        assert_eq!(src_pad.sinks, &["stream_rtsp_out1.input".parse().unwrap()]);
+
+        // and finally check the stream_rtsp_out node
+        let node = pipeline.node_by_id("stream_rtsp_out1").unwrap();
+        assert_eq!(node.id(), "stream_rtsp_out1");
+        assert_eq!(
+            node.properties(),
+            &NodeProperties::StreamRtspOut(StreamRtspOutProperties {
+                uri: Url::from_str("rtsp://127.0.0.1:5555/mycamera").unwrap(),
+                udp_port: 5800
+            })
+        );
+        assert!(node.source_pads().is_empty());
     }
 }

--- a/pipeline/src/node.rs
+++ b/pipeline/src/node.rs
@@ -1,0 +1,38 @@
+use serde::Deserialize;
+
+use crate::{NodeProperties, SourcePads};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Node {
+    id: String,
+    #[serde(flatten)]
+    props: NodeProperties,
+    #[serde(rename = "wires")]
+    source_pads: SourcePads,
+}
+
+impl Node {
+    pub fn new(id: &str, props: NodeProperties, source_pads: Option<SourcePads>) -> Self {
+        Self {
+            id: id.to_string(),
+            props,
+            source_pads: source_pads.unwrap_or_else(SourcePads::new),
+        }
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn properties(&self) -> &NodeProperties {
+        &self.props
+    }
+
+    pub fn source_pads(&self) -> &SourcePads {
+        &self.source_pads
+    }
+
+    pub fn source_pads_mut(&mut self) -> &mut SourcePads {
+        &mut self.source_pads
+    }
+}

--- a/pipeline/src/node_properties/clip_properties.rs
+++ b/pipeline/src/node_properties/clip_properties.rs
@@ -1,0 +1,34 @@
+use std::path::PathBuf;
+use url::Url;
+
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct ClipProperties {
+    pub path: Option<PathBuf>,
+    pub max_duration_sec: Option<u64>,
+    pub max_size_bytes: Option<u64>,
+    pub max_edge_files: Option<u64>,
+    pub edge_retention_duration: Option<u64>,
+    pub cloud_upload: Option<bool>,
+    pub cloud_retention_duration: Option<u64>,
+    pub webhook_url: Option<Url>,
+}
+
+// We can ditch this manual Deserialize impl. after changing the properties to specific types.
+impl<'de> serde::de::Deserialize<'de> for ClipProperties {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
+        Ok(ClipProperties {
+            path: super::get_option(&props, "path")?,
+            max_duration_sec: super::get_option(&props, "max_duration_sec")?,
+            max_size_bytes: super::get_option(&props, "max_size_bytes")?,
+            max_edge_files: super::get_option(&props, "max_edge_files")?,
+            edge_retention_duration: super::get_option(&props, "edge_retention_duration")?,
+            cloud_upload: super::get_option(&props, "cloud_upload")?,
+            cloud_retention_duration: super::get_option(&props, "cloud_retention_duration")?,
+            webhook_url: super::get_option(&props, "webhook_url")?,
+        })
+    }
+}

--- a/pipeline/src/node_properties/convert_properties.rs
+++ b/pipeline/src/node_properties/convert_properties.rs
@@ -1,0 +1,19 @@
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct ConvertProperties {
+    pub fps: Option<u32>,
+    pub resolution: Option<crate::Resolution>,
+}
+
+// We can ditch this manual Deserialize impl. after changing the properties to specific types.
+impl<'de> serde::de::Deserialize<'de> for ConvertProperties {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
+        Ok(ConvertProperties {
+            fps: super::get_option(&props, "fps")?,
+            resolution: super::get_option(&props, "resolution")?,
+        })
+    }
+}

--- a/pipeline/src/node_properties/csi_camera_properties.rs
+++ b/pipeline/src/node_properties/csi_camera_properties.rs
@@ -1,0 +1,23 @@
+use crate::resolution::Resolution;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CsiCameraProperties {
+    pub uri: url::Url,
+    pub resolution: Option<Resolution>,
+    pub framerate: Option<u32>,
+}
+
+// We can ditch this manual Deserialize impl. after changing the properties to specific types.
+impl<'de> serde::de::Deserialize<'de> for CsiCameraProperties {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
+        Ok(CsiCameraProperties {
+            uri: super::get_required(&props, "uri")?,
+            resolution: super::get_option(&props, "resolution")?,
+            framerate: super::get_option(&props, "framerate")?,
+        })
+    }
+}

--- a/pipeline/src/node_properties/encode_properties.rs
+++ b/pipeline/src/node_properties/encode_properties.rs
@@ -1,0 +1,25 @@
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct EncodeProperties {
+    pub codec: String,
+    pub max_bitrate: Option<u32>,
+    pub bitrate: Option<u32>,
+    pub quality: Option<u32>,
+    pub fps: Option<u32>,
+}
+
+// We can ditch this manual Deserialize impl. after changing the properties to specific types.
+impl<'de> serde::de::Deserialize<'de> for EncodeProperties {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
+        Ok(EncodeProperties {
+            codec: super::get_required(&props, "codec")?,
+            max_bitrate: super::get_option(&props, "max_bitrate")?,
+            bitrate: super::get_option(&props, "bitrate")?,
+            quality: super::get_option(&props, "quality")?,
+            fps: super::get_option(&props, "fps")?,
+        })
+    }
+}

--- a/pipeline/src/node_properties/function_properties.rs
+++ b/pipeline/src/node_properties/function_properties.rs
@@ -1,0 +1,6 @@
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct FunctionProperties {
+    pub module: String,
+}

--- a/pipeline/src/node_properties/ip_camera_properties.rs
+++ b/pipeline/src/node_properties/ip_camera_properties.rs
@@ -1,0 +1,23 @@
+use crate::resolution::Resolution;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct IpCameraProperties {
+    pub uri: url::Url,
+    pub resolution: Option<Resolution>,
+    pub framerate: Option<u32>,
+}
+
+// We can ditch this manual Deserialize impl. after changing the properties to specific types.
+impl<'de> serde::de::Deserialize<'de> for IpCameraProperties {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
+        Ok(IpCameraProperties {
+            uri: super::get_required(&props, "uri")?,
+            resolution: super::get_option(&props, "resolution")?,
+            framerate: super::get_option(&props, "framerate")?,
+        })
+    }
+}

--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -1,0 +1,77 @@
+//! This module contains all kinds of Lumeo pipeline nodes
+
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+// FIXME: These functions will go away once props in TOML are more strictly-typed
+fn get_option<T, E>(props: &HashMap<String, String>, key: &str) -> Result<Option<T>, E>
+where
+    T: FromStr,
+    T::Err: ToString,
+    E: serde::de::Error,
+{
+    props
+        .get(key)
+        .filter(|val| !val.is_empty())
+        .map(|val| val.parse::<T>())
+        .transpose()
+        .map_err(|e| serde::de::Error::custom(&e.to_string()))
+}
+
+fn get_required<T, E>(props: &HashMap<String, String>, key: &'static str) -> Result<T, E>
+where
+    T: FromStr,
+    T::Err: ToString,
+    E: serde::de::Error,
+{
+    match props.get(key) {
+        Some(val) => val
+            .parse::<T>()
+            .map_err(|e| serde::de::Error::custom(&e.to_string())),
+        None => Err(serde::de::Error::missing_field(key)),
+    }
+}
+
+pub mod encode_properties;
+pub use encode_properties::EncodeProperties;
+pub mod stream_rtsp_out_properties;
+pub use stream_rtsp_out_properties::StreamRtspOutProperties;
+pub mod stream_web_rtc_out_properties;
+pub use stream_web_rtc_out_properties::StreamWebRtcOutProperties;
+pub mod csi_camera_properties;
+pub use csi_camera_properties::CsiCameraProperties;
+pub mod usb_camera_properties;
+pub use usb_camera_properties::UsbCameraProperties;
+pub mod ip_camera_properties;
+pub use ip_camera_properties::IpCameraProperties;
+pub mod convert_properties;
+pub use convert_properties::ConvertProperties;
+pub mod model_inference_properties;
+pub use model_inference_properties::ModelInferenceProperties;
+pub mod overlay_properties;
+pub use overlay_properties::OverlayProperties;
+pub mod clip_properties;
+pub use clip_properties::ClipProperties;
+pub mod snapshot_properties;
+pub use snapshot_properties::SnapshotProperties;
+pub mod function_properties;
+pub use function_properties::FunctionProperties;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[allow(clippy::large_enum_variant)]
+#[serde(tag = "type", content = "properties", rename_all = "snake_case")]
+pub enum NodeProperties {
+    UsbCamera(UsbCameraProperties),
+    CsiCamera(CsiCameraProperties),
+    IpCamera(IpCameraProperties),
+    Encode(EncodeProperties),
+    Convert(ConvertProperties),
+    ModelInference(ModelInferenceProperties),
+    Overlay(OverlayProperties),
+    Clip(ClipProperties),
+    Snapshot(SnapshotProperties),
+    StreamRtspOut(StreamRtspOutProperties),
+    StreamWebRtcOut(StreamWebRtcOutProperties),
+    Function(FunctionProperties),
+}

--- a/pipeline/src/node_properties/model_inference_properties.rs
+++ b/pipeline/src/node_properties/model_inference_properties.rs
@@ -1,0 +1,6 @@
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct ModelInferenceProperties {
+    pub config: url::Url,
+}

--- a/pipeline/src/node_properties/overlay_properties.rs
+++ b/pipeline/src/node_properties/overlay_properties.rs
@@ -1,0 +1,4 @@
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct OverlayProperties {}

--- a/pipeline/src/node_properties/snapshot_properties.rs
+++ b/pipeline/src/node_properties/snapshot_properties.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+use url::Url;
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SnapshotProperties {
+    pub path: Option<PathBuf>,
+    pub max_edge_files: Option<u64>,
+    pub edge_retention_duration: Option<u64>,
+    pub cloud_upload: Option<bool>,
+    pub cloud_retention_duration: Option<u64>,
+    pub webhook_url: Option<Url>,
+}
+
+// We can ditch this manual Deserialize impl. after changing the properties to specific types.
+impl<'de> serde::de::Deserialize<'de> for SnapshotProperties {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
+        Ok(SnapshotProperties {
+            path: super::get_option(&props, "path")?,
+            max_edge_files: super::get_option(&props, "max_edge_files")?,
+            edge_retention_duration: super::get_option(&props, "edge_retention_duration")?,
+            cloud_upload: super::get_option(&props, "cloud_upload")?,
+            cloud_retention_duration: super::get_option(&props, "cloud_retention_duration")?,
+            webhook_url: super::get_option(&props, "webhook_url")?,
+        })
+    }
+}

--- a/pipeline/src/node_properties/stream_rtsp_out_properties.rs
+++ b/pipeline/src/node_properties/stream_rtsp_out_properties.rs
@@ -1,0 +1,21 @@
+use url::Url;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StreamRtspOutProperties {
+    pub uri: Url,
+    pub udp_port: u16,
+}
+
+// We can ditch this manual Deserialize impl. after changing the properties to specific types.
+impl<'de> serde::de::Deserialize<'de> for StreamRtspOutProperties {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
+        Ok(StreamRtspOutProperties {
+            uri: super::get_required(&props, "uri")?,
+            udp_port: super::get_required(&props, "udp_port")?,
+        })
+    }
+}

--- a/pipeline/src/node_properties/stream_web_rtc_out_properties.rs
+++ b/pipeline/src/node_properties/stream_web_rtc_out_properties.rs
@@ -1,0 +1,21 @@
+use url::Url;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StreamWebRtcOutProperties {
+    pub uri: Url,
+    pub udp_port: u16,
+}
+
+// We can ditch this manual Deserialize impl. after changing the properties to specific types.
+impl<'de> serde::de::Deserialize<'de> for StreamWebRtcOutProperties {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
+        Ok(StreamWebRtcOutProperties {
+            uri: super::get_required(&props, "uri")?,
+            udp_port: super::get_required(&props, "udp_port")?,
+        })
+    }
+}

--- a/pipeline/src/node_properties/usb_camera_properties.rs
+++ b/pipeline/src/node_properties/usb_camera_properties.rs
@@ -1,0 +1,23 @@
+use crate::resolution::Resolution;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UsbCameraProperties {
+    pub uri: url::Url,
+    pub resolution: Option<Resolution>,
+    pub framerate: Option<u32>,
+}
+
+// We can ditch this manual Deserialize impl. after changing the properties to specific types.
+impl<'de> serde::de::Deserialize<'de> for UsbCameraProperties {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
+        Ok(UsbCameraProperties {
+            uri: super::get_required(&props, "uri")?,
+            resolution: super::get_option(&props, "resolution")?,
+            framerate: super::get_option(&props, "framerate")?,
+        })
+    }
+}

--- a/pipeline/src/pad.rs
+++ b/pipeline/src/pad.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
+use serde::de::{Error, Unexpected};
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SinkPad {
+    // FIXME: this should be a Node ref
+    pub node: String,
+    pub name: String,
+}
+
+impl FromStr for SinkPad {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.split('.').collect::<Vec<_>>()[..] {
+            [node, name] => Ok(SinkPad {
+                node: node.to_string(),
+                name: name.to_string(),
+            }),
+            _ => Err("Bad pad format".to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourcePad {
+    pub name: String,
+    pub sinks: Vec<SinkPad>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SourcePads(HashMap<String, SourcePad>);
+
+impl SourcePads {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn add(&mut self, pad: SourcePad) {
+        self.0.insert(pad.name.clone(), pad);
+    }
+
+    pub fn get(&self, name: &str) -> Option<&SourcePad> {
+        self.0.get(name)
+    }
+
+    pub fn all(&self) -> Vec<&SourcePad> {
+        self.0.values().collect()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+// FIXME: Manual Deserialize is complicated. We should change the serialized YAML format so we don't
+// need to do this and just use the derive macro.
+impl<'de> Deserialize<'de> for SourcePads {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let visitor = SourcePadsVisitor;
+
+        deserializer.deserialize_map(visitor)
+    }
+}
+
+struct SourcePadsVisitor;
+
+impl<'de> Visitor<'de> for SourcePadsVisitor {
+    type Value = SourcePads;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a node's source pad")
+    }
+
+    fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        let mut pads = SourcePads::new();
+        while let Some(name) = map.next_key::<String>()? {
+            let sinks = map.next_value::<Vec<String>>()?;
+            let mut pad = SourcePad {
+                name,
+                sinks: vec![],
+            };
+            for sink in sinks {
+                let sink_pad = SinkPad::from_str(&sink).map_err(|_| {
+                    Error::invalid_value(Unexpected::Str(&sink), &"NODE_ID.SINK_PAD_NAME")
+                })?;
+                pad.sinks.push(sink_pad);
+            }
+            pads.add(pad);
+        }
+
+        Ok(pads)
+    }
+}

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -1,0 +1,56 @@
+use std::collections::HashMap;
+
+use serde::de::{Deserialize, Deserializer, Error};
+
+use crate::Node;
+
+#[derive(Default, Debug, Clone)]
+pub struct Pipeline {
+    nodes: HashMap<String, Node>,
+}
+
+impl Pipeline {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn add_node(&mut self, node: Node) {
+        self.nodes.insert(node.id().to_string(), node);
+    }
+
+    pub fn nodes(&self) -> Vec<&Node> {
+        self.nodes.values().collect()
+    }
+
+    pub fn node_by_id(&self, id: &str) -> Option<&Node> {
+        self.nodes.get(id)
+    }
+}
+
+// Manual implemention is needed here as we need to verify source pads don't link to inexistant
+// sink pads.
+impl<'de> Deserialize<'de> for Pipeline {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let nodes = <Vec<Node>>::deserialize(deserializer)?;
+        let mut pipeline = Pipeline::new();
+        for node in nodes {
+            pipeline.add_node(node);
+        }
+
+        // Ensure all sink pads are setup correctly
+        for node in pipeline.nodes() {
+            for src_pad in node.source_pads().all() {
+                for sink in &src_pad.sinks {
+                    pipeline.node_by_id(&sink.node).ok_or_else(|| {
+                        Error::custom(&format!("Destination node `{}` not foud", sink.node))
+                    })?;
+                }
+            }
+        }
+
+        Ok(pipeline)
+    }
+}

--- a/pipeline/src/resolution.rs
+++ b/pipeline/src/resolution.rs
@@ -1,0 +1,45 @@
+use serde::de::{Deserialize, Deserializer, Error};
+use serde::ser::{Serialize, Serializer};
+use std::str::FromStr;
+
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct Resolution {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl FromStr for Resolution {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.split('x').collect::<Vec<_>>()[..] {
+            [width, height] => match (width.parse(), height.parse()) {
+                (Ok(width), Ok(height)) => Ok(Resolution { width, height }),
+                _ => Err("Resolution must be a number".to_string()),
+            },
+            _ => Err(format!("Bad resolution format: {}", s)),
+        }
+    }
+}
+
+impl Serialize for Resolution {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = format!("{}x{}", self.width, self.height);
+
+        serializer.serialize_str(&s)
+    }
+}
+
+impl<'de> Deserialize<'de> for Resolution {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        Resolution::from_str(&s).map_err(Error::custom)
+    }
+}


### PR DESCRIPTION
This is mostly just moving code from lumeo-gst/lumeostream right now.

Perhaps this is the perfect opportunity to address [this FIXME](https://github.com/lumeohq/lumeo-types-rs/blob/zeenix/ch985/pipelines-crate/pipeline/src/node.rs#L9)? WDYT @DmitrySamoylov @jplatte ?