### PR TITLE
Fix WebRTC

### DIFF
--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -72,6 +72,7 @@ pub enum NodeProperties {
     Clip(ClipProperties),
     Snapshot(SnapshotProperties),
     StreamRtspOut(StreamRtspOutProperties),
+    #[serde(rename = "stream_webrtc_out")]
     StreamWebRtcOut(StreamWebRtcOutProperties),
     Function(FunctionProperties),
 }


### PR DESCRIPTION
In serialized form we expect `stream_webrtc_out` property (according to docs). But `StreamWebRtcOut` is counted by serde as `stream_web_rtc_out` so I added an explicit rename.