### PR TITLE
Dmitrysamoylov/ch986/use pipeline crate lumeod

### DIFF
--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -15,7 +15,9 @@ mod tests {
     use std::str::FromStr;
     use url::Url;
 
-    use crate::{EncodeProperties, StreamRtspOutProperties, UsbCameraProperties};
+    use crate::{
+        EncodeProperties, StreamRtspOutProperties, StreamRtspOutRuntime, UsbCameraProperties,
+    };
     use crate::{Node, NodeProperties, Pipeline, Resolution};
     use crate::{SinkPad, SourcePad, SourcePads};
 
@@ -46,7 +48,7 @@ mod tests {
   id: stream_rtsp_out1
   properties:
     uri: rtsp://127.0.0.1:5555/mycamera
-    udp_port: '5800'
+    udp_port: 5800
   wires: {}"#;
 
         let pipeline: Pipeline = serde_yaml::from_str(yaml).unwrap();
@@ -144,8 +146,10 @@ mod tests {
 
     fn stream_rtsp_out_properties() -> NodeProperties {
         NodeProperties::StreamRtspOut(StreamRtspOutProperties {
-            uri: Url::from_str("rtsp://127.0.0.1:5555/mycamera").unwrap(),
-            udp_port: 5800,
+            runtime: StreamRtspOutRuntime {
+                uri: Some(Url::from_str("rtsp://127.0.0.1:5555/mycamera").unwrap()),
+                udp_port: Some(5800),
+            },
         })
     }
 }

--- a/pipeline/src/node.rs
+++ b/pipeline/src/node.rs
@@ -28,6 +28,10 @@ impl Node {
         &self.props
     }
 
+    pub fn properties_mut(&mut self) -> &mut NodeProperties {
+        &mut self.props
+    }
+
     pub fn source_pads(&self) -> &SourcePads {
         &self.source_pads
     }

--- a/pipeline/src/node_properties/function_properties.rs
+++ b/pipeline/src/node_properties/function_properties.rs
@@ -2,5 +2,20 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct FunctionProperties {
-    pub module: String,
+    pub code: String,
+    #[serde(flatten)]
+    pub runtime: FunctionRuntime,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct FunctionRuntime {
+    /// Path to python module.
+    ///
+    /// This field is set to `Some` by `lumeod`.
+    ///
+    /// `lumeod` receives code as a string blob (`FunctionProperties::code`) but gvapython
+    /// element requires a path to ".py" file, so lumeod stores code in a file and sets
+    /// `module` field to file path.
+    // TODO: replace String with fs::PathBuf
+    pub module: Option<String>,
 }

--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -45,20 +45,14 @@ where
     }
 }
 
-fn serialize_required<T, S>(field: &T, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::ser::Serializer,
-    T: Display,
-{
-    field.to_string().serialize(serializer)
-}
-
 pub mod encode_properties;
 pub use encode_properties::EncodeProperties;
 pub mod stream_rtsp_out_properties;
 pub use stream_rtsp_out_properties::StreamRtspOutProperties;
+pub use stream_rtsp_out_properties::StreamRtspOutRuntime;
 pub mod stream_web_rtc_out_properties;
 pub use stream_web_rtc_out_properties::StreamWebRtcOutProperties;
+pub use stream_web_rtc_out_properties::StreamWebRtcOutRuntime;
 pub mod csi_camera_properties;
 pub use csi_camera_properties::CsiCameraProperties;
 pub mod usb_camera_properties;
@@ -69,6 +63,7 @@ pub mod convert_properties;
 pub use convert_properties::ConvertProperties;
 pub mod model_inference_properties;
 pub use model_inference_properties::ModelInferenceProperties;
+pub use model_inference_properties::ModelInferenceRuntime;
 pub mod overlay_properties;
 pub use overlay_properties::OverlayProperties;
 pub mod clip_properties;
@@ -77,6 +72,7 @@ pub mod snapshot_properties;
 pub use snapshot_properties::SnapshotProperties;
 pub mod function_properties;
 pub use function_properties::FunctionProperties;
+pub use function_properties::FunctionRuntime;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]

--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -48,11 +48,9 @@ where
 pub mod encode_properties;
 pub use encode_properties::EncodeProperties;
 pub mod stream_rtsp_out_properties;
-pub use stream_rtsp_out_properties::StreamRtspOutProperties;
-pub use stream_rtsp_out_properties::StreamRtspOutRuntime;
+pub use stream_rtsp_out_properties::{StreamRtspOutProperties, StreamRtspOutRuntime};
 pub mod stream_web_rtc_out_properties;
-pub use stream_web_rtc_out_properties::StreamWebRtcOutProperties;
-pub use stream_web_rtc_out_properties::StreamWebRtcOutRuntime;
+pub use stream_web_rtc_out_properties::{StreamWebRtcOutProperties, StreamWebRtcOutRuntime};
 pub mod csi_camera_properties;
 pub use csi_camera_properties::CsiCameraProperties;
 pub mod usb_camera_properties;
@@ -62,8 +60,7 @@ pub use ip_camera_properties::IpCameraProperties;
 pub mod convert_properties;
 pub use convert_properties::ConvertProperties;
 pub mod model_inference_properties;
-pub use model_inference_properties::ModelInferenceProperties;
-pub use model_inference_properties::ModelInferenceRuntime;
+pub use model_inference_properties::{ModelInferenceProperties, ModelInferenceRuntime};
 pub mod overlay_properties;
 pub use overlay_properties::OverlayProperties;
 pub mod clip_properties;
@@ -71,8 +68,7 @@ pub use clip_properties::ClipProperties;
 pub mod snapshot_properties;
 pub use snapshot_properties::SnapshotProperties;
 pub mod function_properties;
-pub use function_properties::FunctionProperties;
-pub use function_properties::FunctionRuntime;
+pub use function_properties::{FunctionProperties, FunctionRuntime};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]

--- a/pipeline/src/node_properties/model_inference_properties.rs
+++ b/pipeline/src/node_properties/model_inference_properties.rs
@@ -2,5 +2,18 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ModelInferenceProperties {
-    pub config: url::Url,
+    pub runtime: ModelInferenceRuntime,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ModelInferenceRuntime {
+    /// Path to the inferencing node config.
+    ///
+    /// This field is set to `Some` by `lumeod`.
+    ///
+    /// Inferencing GStreamer element requires config to be stored locally
+    /// so `lumeod` should download everything required for model to run
+    /// and generate a config.
+    // TODO: replace url::Url with fs::PathBuf
+    pub config: Option<url::Url>,
 }

--- a/pipeline/src/node_properties/stream_rtsp_out_properties.rs
+++ b/pipeline/src/node_properties/stream_rtsp_out_properties.rs
@@ -1,25 +1,26 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
-// Ditch all manual Serialize + Deserialize code after changing the properties to specific types.
-// This includes the use of `serialize_with` attribute.
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StreamRtspOutProperties {
-    pub uri: Url,
-    #[serde(serialize_with = "super::serialize_required")]
-    pub udp_port: u16,
+    #[serde(flatten)]
+    pub runtime: StreamRtspOutRuntime,
 }
 
-impl<'de> serde::de::Deserialize<'de> for StreamRtspOutProperties {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
-        Ok(StreamRtspOutProperties {
-            uri: super::get_required(&props, "uri")?,
-            udp_port: super::get_required(&props, "udp_port")?,
-        })
-    }
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StreamRtspOutRuntime {
+    /// RTSP stream URI.
+    ///
+    /// This field is set to `Some` by `lumeod`.
+    // TODO: this should be set by API server, more details here:
+    //       https://app.clubhouse.io/lumeo/story/940/set-correct-stream-url-for-pipeline-streams-created-for-webrtc-nodes
+    pub uri: Option<Url>,
+
+    /// UDP port for `udpsink` element.
+    ///
+    /// This field is set to `Some` by `lumeod`
+    ///
+    /// Since pipeline can have multiple RTSP output streams we need to
+    /// distribute ports at `lumeod` level.
+    pub udp_port: Option<u16>,
 }

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -23,6 +23,10 @@ impl Pipeline {
         self.nodes.values()
     }
 
+    pub fn nodes_mut(&mut self) -> impl Iterator<Item = &mut Node> {
+        self.nodes.values_mut()
+    }
+
     pub fn node_by_id(&self, id: &str) -> Option<&Node> {
         self.nodes.get(id)
     }


### PR DESCRIPTION
Added only those properties that are inserted or used by `lumeod`.

Previously such properties were inserted in `properties: HashMap` and now we only set corresponding `Option`s to `Some`.

Corresponding PR in lumeod: https://github.com/lumeohq/lumeod/pull/38

Story: https://app.clubhouse.io/lumeo/story/986/use-pipeline-crate-lumeod