### PR TITLE
pipeline: Make API usable for API server + a bunch of additions/fixes/improvements

### DIFF
--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 url = { version = "2.1", features = ["serde"] }
+uuid = { version = "0.8", features = ["v4", "serde"] }
 
 [dev-dependencies]
 serde_yaml = "0.8.11"

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -151,7 +151,7 @@ mod tests {
     fn stream_rtsp_out_properties() -> NodeProperties {
         NodeProperties::StreamRtspOut(StreamRtspOutProperties {
             runtime: StreamRtspOutRuntime {
-                uri: Some(Url::from_str("rtsp://127.0.0.1:5555/mycamera").unwrap()),
+                uri: Url::from_str("rtsp://127.0.0.1:5555/mycamera").unwrap(),
                 udp_port: Some(5800),
                 stream_id: None,
             },

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -17,6 +17,7 @@ mod tests {
 
     use crate::{
         EncodeProperties, StreamRtspOutProperties, StreamRtspOutRuntime, UsbCameraProperties,
+        UsbCameraRuntime,
     };
     use crate::{Node, NodeProperties, Pipeline, Resolution};
     use crate::{SinkPad, SourcePad, SourcePads};
@@ -125,13 +126,15 @@ mod tests {
 
     fn usb_camera_properties() -> NodeProperties {
         NodeProperties::UsbCamera(UsbCameraProperties {
-            uri: Url::from_str("file:///dev/video0").unwrap(),
             framerate: Some(15),
             resolution: Some(Resolution {
                 width: 720,
                 height: 480,
             }),
-            runtime: Default::default(),
+            runtime: UsbCameraRuntime {
+                uri: Url::from_str("file:///dev/video0").unwrap(),
+                source: None,
+            },
         })
     }
 

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -29,6 +29,7 @@ mod tests {
   properties:
     type: usb_camera
     uri: file:///dev/video0
+    source: usb_1
     framerate: 15
     resolution: 720x480
   wires:
@@ -126,6 +127,7 @@ mod tests {
 
     fn usb_camera_properties() -> NodeProperties {
         NodeProperties::UsbCamera(UsbCameraProperties {
+            source: String::from("usb_1"),
             framerate: Some(15),
             resolution: Some(Resolution {
                 width: 720,
@@ -133,7 +135,6 @@ mod tests {
             }),
             runtime: UsbCameraRuntime {
                 uri: Url::from_str("file:///dev/video0").unwrap(),
-                source: None,
             },
         })
     }

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -24,9 +24,9 @@ mod tests {
     #[test]
     fn pipeline_nodes_de() {
         let yaml = r#"---
-- type: usb_camera
-  id: camera1
+- id: camera1
   properties:
+    type: usb_camera
     uri: file:///dev/video0
     framerate: '15'
     resolution: 720x480
@@ -34,9 +34,9 @@ mod tests {
     video:
       - encode1.input
     snapshot: []
-- type: encode
-  id: encode1
+- id: encode1
   properties:
+    type: encode
     codec: 'h264'
     max_bitrate: '1500000'
     quality: '10'
@@ -44,9 +44,9 @@ mod tests {
   wires:
     output:
       - stream_rtsp_out1.input
-- type: stream_rtsp_out
-  id: stream_rtsp_out1
+- id: stream_rtsp_out1
   properties:
+    type: stream_rtsp_out
     uri: rtsp://127.0.0.1:5555/mycamera
     udp_port: 5800
   wires: {}"#;

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -131,6 +131,7 @@ mod tests {
                 width: 720,
                 height: 480,
             }),
+            runtime: Default::default(),
         })
     }
 
@@ -149,6 +150,7 @@ mod tests {
             runtime: StreamRtspOutRuntime {
                 uri: Some(Url::from_str("rtsp://127.0.0.1:5555/mycamera").unwrap()),
                 udp_port: Some(5800),
+                stream_id: None,
             },
         })
     }

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -28,7 +28,7 @@ mod tests {
   properties:
     type: usb_camera
     uri: file:///dev/video0
-    framerate: '15'
+    framerate: 15
     resolution: 720x480
   wires:
     video:
@@ -38,9 +38,9 @@ mod tests {
   properties:
     type: encode
     codec: 'h264'
-    max_bitrate: '1500000'
-    quality: '10'
-    fps: '15'
+    max_bitrate: 1500000
+    quality: 10
+    fps: 15
   wires:
     output:
       - stream_rtsp_out1.input

--- a/pipeline/src/node.rs
+++ b/pipeline/src/node.rs
@@ -5,17 +5,16 @@ use crate::{NodeProperties, SourcePads};
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Node {
     id: String,
-    #[serde(flatten)]
-    props: NodeProperties,
+    properties: NodeProperties,
     #[serde(rename = "wires")]
     source_pads: SourcePads,
 }
 
 impl Node {
-    pub fn new(id: &str, props: NodeProperties, source_pads: Option<SourcePads>) -> Self {
+    pub fn new(id: &str, properties: NodeProperties, source_pads: Option<SourcePads>) -> Self {
         Self {
             id: id.to_string(),
-            props,
+            properties,
             source_pads: source_pads.unwrap_or_else(SourcePads::new),
         }
     }
@@ -25,11 +24,11 @@ impl Node {
     }
 
     pub fn properties(&self) -> &NodeProperties {
-        &self.props
+        &self.properties
     }
 
     pub fn properties_mut(&mut self) -> &mut NodeProperties {
-        &mut self.props
+        &mut self.properties
     }
 
     pub fn source_pads(&self) -> &SourcePads {

--- a/pipeline/src/node_properties/camera_properties.rs
+++ b/pipeline/src/node_properties/camera_properties.rs
@@ -1,0 +1,112 @@
+use crate::resolution::Resolution;
+
+pub trait CameraProperties {
+    type Runtime: CameraRuntime;
+
+    fn uri(&self) -> &url::Url;
+    fn set_uri(&mut self, url: url::Url);
+    fn resolution(&self) -> Option<&Resolution>;
+    fn set_resolution(&mut self, resolution: Option<Resolution>);
+    fn framerate(&self) -> Option<u32>;
+    fn set_framerate(&mut self, framerate: Option<u32>);
+    fn runtime(&self) -> &Self::Runtime;
+    fn runtime_mut(&mut self) -> &mut Self::Runtime;
+}
+
+pub trait CameraRuntime {
+    fn source(&self) -> Option<&str>;
+    fn set_source(&mut self, source: Option<String>);
+}
+
+macro_rules! impl_camera_props {
+    ($camera_type:ty, $runtime: ty) => {
+        impl crate::CameraProperties for $camera_type {
+            type Runtime = $runtime;
+
+            fn uri(&self) -> &url::Url {
+                &self.uri
+            }
+
+            fn set_uri(&mut self, uri: url::Url) {
+                self.uri = uri
+            }
+
+            fn resolution(&self) -> Option<&Resolution> {
+                self.resolution.as_ref()
+            }
+
+            fn set_resolution(&mut self, resolution: Option<Resolution>) {
+                self.resolution = resolution;
+            }
+
+            fn framerate(&self) -> Option<u32> {
+                self.framerate
+            }
+
+            fn set_framerate(&mut self, framerate: Option<u32>) {
+                self.framerate = framerate;
+            }
+
+            fn runtime(&self) -> &$runtime {
+                &self.runtime
+            }
+
+            fn runtime_mut(&mut self) -> &mut $runtime {
+                &mut self.runtime
+            }
+        }
+
+        impl crate::CameraRuntime for $runtime {
+            fn source(&self) -> Option<&str> {
+                self.source.as_deref()
+            }
+
+            fn set_source(&mut self, source: Option<String>) {
+                self.source = source;
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{CameraProperties, CameraRuntime, Resolution};
+    use crate::{UsbCameraProperties, UsbCameraRuntime};
+    use std::str::FromStr;
+    use url::Url;
+
+    // A simple unit test to ensure our trait works as expected, i-e specific Camera properties
+    // types can be used easily/nicely in a generic context.
+    #[test]
+    fn generic_camera_api() {
+        let usb_camera = UsbCameraProperties {
+            uri: Url::from_str("file:///whatever").unwrap(),
+            runtime: UsbCameraRuntime {
+                source: Some(String::from("USB")),
+            },
+            resolution: Some(Resolution {
+                width: 640,
+                height: 480,
+            }),
+            framerate: Some(30),
+        };
+
+        check_camera_props(&usb_camera);
+    }
+
+    fn check_camera_props<C>(camera: &C)
+    where
+        C: CameraProperties,
+    {
+        assert_eq!(camera.uri(), &Url::from_str("file:///whatever").unwrap());
+        assert_eq!(camera.framerate().unwrap(), 30);
+        assert_eq!(
+            *camera.resolution().unwrap(),
+            Resolution {
+                width: 640,
+                height: 480,
+            },
+        );
+        assert_eq!(camera.runtime().source().unwrap(), "USB");
+    }
+}

--- a/pipeline/src/node_properties/camera_properties.rs
+++ b/pipeline/src/node_properties/camera_properties.rs
@@ -7,6 +7,8 @@ pub trait CameraProperties {
     fn set_resolution(&mut self, resolution: Option<Resolution>);
     fn framerate(&self) -> Option<u32>;
     fn set_framerate(&mut self, framerate: Option<u32>);
+    fn source(&self) -> &str;
+    fn set_source(&mut self, source: String);
     fn runtime(&self) -> &Self::Runtime;
     fn runtime_mut(&mut self) -> &mut Self::Runtime;
 }
@@ -14,8 +16,6 @@ pub trait CameraProperties {
 pub trait CameraRuntime {
     fn uri(&self) -> &url::Url;
     fn set_uri(&mut self, url: url::Url);
-    fn source(&self) -> Option<&str>;
-    fn set_source(&mut self, source: Option<String>);
 }
 
 macro_rules! impl_camera_props {
@@ -39,6 +39,14 @@ macro_rules! impl_camera_props {
                 self.framerate = framerate;
             }
 
+            fn source(&self) -> &str {
+                &self.source
+            }
+
+            fn set_source(&mut self, source: String) {
+                self.source = source;
+            }
+
             fn runtime(&self) -> &$runtime {
                 &self.runtime
             }
@@ -56,14 +64,6 @@ macro_rules! impl_camera_props {
             fn set_uri(&mut self, uri: url::Url) {
                 self.uri = uri
             }
-
-            fn source(&self) -> Option<&str> {
-                self.source.as_deref()
-            }
-
-            fn set_source(&mut self, source: Option<String>) {
-                self.source = source;
-            }
         }
     };
 }
@@ -80,9 +80,9 @@ mod test {
     #[test]
     fn generic_camera_api() {
         let usb_camera = UsbCameraProperties {
+            source: String::from("USB"),
             runtime: UsbCameraRuntime {
                 uri: Url::from_str("file:///whatever").unwrap(),
-                source: Some(String::from("USB")),
             },
             resolution: Some(Resolution {
                 width: 640,
@@ -98,6 +98,7 @@ mod test {
     where
         C: CameraProperties,
     {
+        assert_eq!(camera.source(), "USB");
         assert_eq!(camera.framerate().unwrap(), 30);
         assert_eq!(
             *camera.resolution().unwrap(),
@@ -110,6 +111,5 @@ mod test {
             camera.runtime().uri(),
             &Url::from_str("file:///whatever").unwrap()
         );
-        assert_eq!(camera.runtime().source().unwrap(), "USB");
     }
 }

--- a/pipeline/src/node_properties/camera_properties.rs
+++ b/pipeline/src/node_properties/camera_properties.rs
@@ -3,8 +3,6 @@ use crate::resolution::Resolution;
 pub trait CameraProperties {
     type Runtime: CameraRuntime;
 
-    fn uri(&self) -> &url::Url;
-    fn set_uri(&mut self, url: url::Url);
     fn resolution(&self) -> Option<&Resolution>;
     fn set_resolution(&mut self, resolution: Option<Resolution>);
     fn framerate(&self) -> Option<u32>;
@@ -14,6 +12,8 @@ pub trait CameraProperties {
 }
 
 pub trait CameraRuntime {
+    fn uri(&self) -> &url::Url;
+    fn set_uri(&mut self, url: url::Url);
     fn source(&self) -> Option<&str>;
     fn set_source(&mut self, source: Option<String>);
 }
@@ -22,14 +22,6 @@ macro_rules! impl_camera_props {
     ($camera_type:ty, $runtime: ty) => {
         impl crate::CameraProperties for $camera_type {
             type Runtime = $runtime;
-
-            fn uri(&self) -> &url::Url {
-                &self.uri
-            }
-
-            fn set_uri(&mut self, uri: url::Url) {
-                self.uri = uri
-            }
 
             fn resolution(&self) -> Option<&Resolution> {
                 self.resolution.as_ref()
@@ -57,6 +49,14 @@ macro_rules! impl_camera_props {
         }
 
         impl crate::CameraRuntime for $runtime {
+            fn uri(&self) -> &url::Url {
+                &self.uri
+            }
+
+            fn set_uri(&mut self, uri: url::Url) {
+                self.uri = uri
+            }
+
             fn source(&self) -> Option<&str> {
                 self.source.as_deref()
             }
@@ -80,8 +80,8 @@ mod test {
     #[test]
     fn generic_camera_api() {
         let usb_camera = UsbCameraProperties {
-            uri: Url::from_str("file:///whatever").unwrap(),
             runtime: UsbCameraRuntime {
+                uri: Url::from_str("file:///whatever").unwrap(),
                 source: Some(String::from("USB")),
             },
             resolution: Some(Resolution {
@@ -98,7 +98,6 @@ mod test {
     where
         C: CameraProperties,
     {
-        assert_eq!(camera.uri(), &Url::from_str("file:///whatever").unwrap());
         assert_eq!(camera.framerate().unwrap(), 30);
         assert_eq!(
             *camera.resolution().unwrap(),
@@ -106,6 +105,10 @@ mod test {
                 width: 640,
                 height: 480,
             },
+        );
+        assert_eq!(
+            camera.runtime().uri(),
+            &Url::from_str("file:///whatever").unwrap()
         );
         assert_eq!(camera.runtime().source().unwrap(), "USB");
     }

--- a/pipeline/src/node_properties/clip_properties.rs
+++ b/pipeline/src/node_properties/clip_properties.rs
@@ -1,63 +1,23 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use url::Url;
 
-// Ditch all manual Serialize + Deserialize code after changing the properties to specific types.
-// This includes the use of `serialize_with` attribute.
-
-#[derive(Default, Debug, Clone, PartialEq, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ClipProperties {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_duration_sec: Option<u64>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_size_bytes: Option<u64>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_edge_files: Option<u64>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub edge_retention_duration: Option<u64>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cloud_upload: Option<bool>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cloud_retention_duration: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub webhook_url: Option<Url>,
-}
-
-impl<'de> serde::de::Deserialize<'de> for ClipProperties {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
-        Ok(ClipProperties {
-            path: super::get_option(&props, "path")?,
-            max_duration_sec: super::get_option(&props, "max_duration_sec")?,
-            max_size_bytes: super::get_option(&props, "max_size_bytes")?,
-            max_edge_files: super::get_option(&props, "max_edge_files")?,
-            edge_retention_duration: super::get_option(&props, "edge_retention_duration")?,
-            cloud_upload: super::get_option(&props, "cloud_upload")?,
-            cloud_retention_duration: super::get_option(&props, "cloud_retention_duration")?,
-            webhook_url: super::get_option(&props, "webhook_url")?,
-        })
-    }
 }

--- a/pipeline/src/node_properties/convert_properties.rs
+++ b/pipeline/src/node_properties/convert_properties.rs
@@ -1,28 +1,9 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-// Ditch all manual Serialize + Deserialize code after changing the properties to specific types.
-// This includes the use of `serialize_with` attribute.
-
-#[derive(Default, Debug, Clone, PartialEq, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ConvertProperties {
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fps: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<crate::Resolution>,
-}
-
-impl<'de> serde::de::Deserialize<'de> for ConvertProperties {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
-        Ok(ConvertProperties {
-            fps: super::get_option(&props, "fps")?,
-            resolution: super::get_option(&props, "resolution")?,
-        })
-    }
 }

--- a/pipeline/src/node_properties/csi_camera_properties.rs
+++ b/pipeline/src/node_properties/csi_camera_properties.rs
@@ -17,3 +17,5 @@ pub struct CsiCameraRuntime {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
 }
+
+impl_camera_props!(CsiCameraProperties, CsiCameraRuntime);

--- a/pipeline/src/node_properties/csi_camera_properties.rs
+++ b/pipeline/src/node_properties/csi_camera_properties.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CsiCameraProperties {
-    pub uri: url::Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<Resolution>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -12,8 +11,9 @@ pub struct CsiCameraProperties {
     pub runtime: CsiCameraRuntime,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CsiCameraRuntime {
+    pub uri: url::Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
 }

--- a/pipeline/src/node_properties/csi_camera_properties.rs
+++ b/pipeline/src/node_properties/csi_camera_properties.rs
@@ -8,4 +8,12 @@ pub struct CsiCameraProperties {
     pub resolution: Option<Resolution>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub framerate: Option<u32>,
+    #[serde(flatten)]
+    pub runtime: CsiCameraRuntime,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CsiCameraRuntime {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }

--- a/pipeline/src/node_properties/csi_camera_properties.rs
+++ b/pipeline/src/node_properties/csi_camera_properties.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CsiCameraProperties {
+    pub source: String,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<Resolution>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -14,8 +16,6 @@ pub struct CsiCameraProperties {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CsiCameraRuntime {
     pub uri: url::Url,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source: Option<String>,
 }
 
 impl_camera_props!(CsiCameraProperties, CsiCameraRuntime);

--- a/pipeline/src/node_properties/csi_camera_properties.rs
+++ b/pipeline/src/node_properties/csi_camera_properties.rs
@@ -1,31 +1,11 @@
 use crate::resolution::Resolution;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-// Ditch all manual Serialize + Deserialize code after changing the properties to specific types.
-// This includes the use of `serialize_with` attribute.
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CsiCameraProperties {
     pub uri: url::Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<Resolution>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub framerate: Option<u32>,
-}
-
-impl<'de> serde::de::Deserialize<'de> for CsiCameraProperties {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
-        Ok(CsiCameraProperties {
-            uri: super::get_required(&props, "uri")?,
-            resolution: super::get_option(&props, "resolution")?,
-            framerate: super::get_option(&props, "framerate")?,
-        })
-    }
 }

--- a/pipeline/src/node_properties/encode_properties.rs
+++ b/pipeline/src/node_properties/encode_properties.rs
@@ -1,45 +1,14 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-// Ditch all manual Serialize + Deserialize code after changing the properties to specific types.
-// This includes the use of `serialize_with` attribute.
-
-#[derive(Default, Debug, Clone, PartialEq, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EncodeProperties {
     pub codec: String,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_bitrate: Option<u32>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bitrate: Option<u32>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub quality: Option<u32>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fps: Option<u32>,
-}
-
-impl<'de> serde::de::Deserialize<'de> for EncodeProperties {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
-        Ok(EncodeProperties {
-            codec: super::get_required(&props, "codec")?,
-            max_bitrate: super::get_option(&props, "max_bitrate")?,
-            bitrate: super::get_option(&props, "bitrate")?,
-            quality: super::get_option(&props, "quality")?,
-            fps: super::get_option(&props, "fps")?,
-        })
-    }
 }

--- a/pipeline/src/node_properties/ip_camera_properties.rs
+++ b/pipeline/src/node_properties/ip_camera_properties.rs
@@ -17,3 +17,5 @@ pub struct IpCameraRuntime {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
 }
+
+impl_camera_props!(IpCameraProperties, IpCameraRuntime);

--- a/pipeline/src/node_properties/ip_camera_properties.rs
+++ b/pipeline/src/node_properties/ip_camera_properties.rs
@@ -33,3 +33,4 @@ pub struct IpCameraRuntime {
 }
 
 impl_camera_props!(IpCameraProperties, IpCameraRuntime);
+impl_stream_props!(IpCameraProperties, IpCameraRuntime, "camera");

--- a/pipeline/src/node_properties/ip_camera_properties.rs
+++ b/pipeline/src/node_properties/ip_camera_properties.rs
@@ -16,6 +16,14 @@ pub struct IpCameraProperties {
 pub struct IpCameraRuntime {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
+
+    /// Stream ID.
+    ///
+    /// This field is set to `Some` by API server.
+    ///
+    /// Stream ID is used by `lumeod` to add a WebRTC endpoint to webrtcstreamer service.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_id: Option<String>,
 }
 
 impl_camera_props!(IpCameraProperties, IpCameraRuntime);

--- a/pipeline/src/node_properties/ip_camera_properties.rs
+++ b/pipeline/src/node_properties/ip_camera_properties.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IpCameraProperties {
+    pub source: String,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<Resolution>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -14,9 +16,6 @@ pub struct IpCameraProperties {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IpCameraRuntime {
     pub uri: url::Url,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source: Option<String>,
 
     /// Stream ID.
     ///

--- a/pipeline/src/node_properties/ip_camera_properties.rs
+++ b/pipeline/src/node_properties/ip_camera_properties.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IpCameraProperties {
-    pub uri: url::Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<Resolution>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -12,8 +11,10 @@ pub struct IpCameraProperties {
     pub runtime: IpCameraRuntime,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IpCameraRuntime {
+    pub uri: url::Url,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
 

--- a/pipeline/src/node_properties/ip_camera_properties.rs
+++ b/pipeline/src/node_properties/ip_camera_properties.rs
@@ -25,6 +25,11 @@ pub struct IpCameraRuntime {
     /// Stream ID is used by `lumeod` to add a WebRTC endpoint to webrtcstreamer service.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_id: Option<String>,
+
+    /// UDP port.
+    ///
+    /// Currently unused.
+    pub udp_port: Option<u16>,
 }
 
 impl_camera_props!(IpCameraProperties, IpCameraRuntime);

--- a/pipeline/src/node_properties/ip_camera_properties.rs
+++ b/pipeline/src/node_properties/ip_camera_properties.rs
@@ -8,4 +8,12 @@ pub struct IpCameraProperties {
     pub resolution: Option<Resolution>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub framerate: Option<u32>,
+    #[serde(flatten)]
+    pub runtime: IpCameraRuntime,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IpCameraRuntime {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }

--- a/pipeline/src/node_properties/ip_camera_properties.rs
+++ b/pipeline/src/node_properties/ip_camera_properties.rs
@@ -1,31 +1,11 @@
 use crate::resolution::Resolution;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-// Ditch all manual Serialize + Deserialize code after changing the properties to specific types.
-// This includes the use of `serialize_with` attribute.
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IpCameraProperties {
     pub uri: url::Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<Resolution>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub framerate: Option<u32>,
-}
-
-impl<'de> serde::de::Deserialize<'de> for IpCameraProperties {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
-        Ok(IpCameraProperties {
-            uri: super::get_required(&props, "uri")?,
-            resolution: super::get_option(&props, "resolution")?,
-            framerate: super::get_option(&props, "framerate")?,
-        })
-    }
 }

--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 #[macro_use]
 pub mod camera_properties;
 pub use camera_properties::{CameraProperties, CameraRuntime};
+#[macro_use]
+pub mod stream_properties;
+pub use stream_properties::{StreamProperties, StreamRuntime};
 pub mod encode_properties;
 pub use encode_properties::EncodeProperties;
 pub mod stream_rtsp_out_properties;

--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -9,11 +9,11 @@ pub use stream_rtsp_out_properties::{StreamRtspOutProperties, StreamRtspOutRunti
 pub mod stream_web_rtc_out_properties;
 pub use stream_web_rtc_out_properties::{StreamWebRtcOutProperties, StreamWebRtcOutRuntime};
 pub mod csi_camera_properties;
-pub use csi_camera_properties::CsiCameraProperties;
+pub use csi_camera_properties::{CsiCameraProperties, CsiCameraRuntime};
 pub mod usb_camera_properties;
-pub use usb_camera_properties::UsbCameraProperties;
+pub use usb_camera_properties::{UsbCameraProperties, UsbCameraRuntime};
 pub mod ip_camera_properties;
-pub use ip_camera_properties::IpCameraProperties;
+pub use ip_camera_properties::{IpCameraProperties, IpCameraRuntime};
 pub mod convert_properties;
 pub use convert_properties::ConvertProperties;
 pub mod model_inference_properties;

--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -2,6 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 
+#[macro_use]
+pub mod camera_properties;
+pub use camera_properties::{CameraProperties, CameraRuntime};
 pub mod encode_properties;
 pub use encode_properties::EncodeProperties;
 pub mod stream_rtsp_out_properties;

--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -1,49 +1,6 @@
 //! This module contains all kinds of Lumeo pipeline nodes
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::fmt::Display;
-use std::str::FromStr;
-
-// FIXME: These functions will go away once props in TOML are more strictly-typed
-fn get_option<T, E>(props: &HashMap<String, String>, key: &str) -> Result<Option<T>, E>
-where
-    T: FromStr,
-    T::Err: ToString,
-    E: serde::de::Error,
-{
-    props
-        .get(key)
-        .filter(|val| !val.is_empty())
-        .map(|val| val.parse::<T>())
-        .transpose()
-        .map_err(|e| serde::de::Error::custom(&e.to_string()))
-}
-
-fn get_required<T, E>(props: &HashMap<String, String>, key: &'static str) -> Result<T, E>
-where
-    T: FromStr,
-    T::Err: ToString,
-    E: serde::de::Error,
-{
-    match props.get(key) {
-        Some(val) => val
-            .parse::<T>()
-            .map_err(|e| serde::de::Error::custom(&e.to_string())),
-        None => Err(serde::de::Error::missing_field(key)),
-    }
-}
-
-fn serialize_option<T, S>(option: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::ser::Serializer,
-    T: Display,
-{
-    match option {
-        Some(field) => serializer.serialize_some(&field.to_string()),
-        None => serializer.serialize_none(),
-    }
-}
 
 pub mod encode_properties;
 pub use encode_properties::EncodeProperties;

--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -72,7 +72,7 @@ pub use function_properties::{FunctionProperties, FunctionRuntime};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
-#[serde(tag = "type", content = "properties", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum NodeProperties {
     UsbCamera(UsbCameraProperties),
     CsiCamera(CsiCameraProperties),

--- a/pipeline/src/node_properties/model_inference_properties.rs
+++ b/pipeline/src/node_properties/model_inference_properties.rs
@@ -1,7 +1,11 @@
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ModelInferenceProperties {
+    /// The ID of the inference model.
+    pub model_id: Uuid,
+
     pub runtime: ModelInferenceRuntime,
 }
 

--- a/pipeline/src/node_properties/snapshot_properties.rs
+++ b/pipeline/src/node_properties/snapshot_properties.rs
@@ -1,48 +1,19 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use url::Url;
 
-// Ditch all manual Serialize + Deserialize code after changing the properties to specific types.
-// This includes the use of `serialize_with` attribute.
-
-#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SnapshotProperties {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_edge_files: Option<u64>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub edge_retention_duration: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cloud_upload: Option<bool>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cloud_retention_duration: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub webhook_url: Option<Url>,
-}
-
-impl<'de> serde::de::Deserialize<'de> for SnapshotProperties {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
-        Ok(SnapshotProperties {
-            path: super::get_option(&props, "path")?,
-            max_edge_files: super::get_option(&props, "max_edge_files")?,
-            edge_retention_duration: super::get_option(&props, "edge_retention_duration")?,
-            cloud_upload: super::get_option(&props, "cloud_upload")?,
-            cloud_retention_duration: super::get_option(&props, "cloud_retention_duration")?,
-            webhook_url: super::get_option(&props, "webhook_url")?,
-        })
-    }
 }

--- a/pipeline/src/node_properties/stream_properties.rs
+++ b/pipeline/src/node_properties/stream_properties.rs
@@ -1,0 +1,57 @@
+pub trait StreamProperties {
+    type Runtime: StreamRuntime;
+
+    fn runtime(&self) -> &Self::Runtime;
+    fn runtime_mut(&mut self) -> &mut Self::Runtime;
+}
+
+pub trait StreamRuntime {
+    fn uri(&self) -> Option<&url::Url>;
+    fn set_uri(&mut self, url: Option<url::Url>);
+    fn udp_port(&self) -> Option<u16>;
+    fn set_udp_port(&mut self, port: Option<u16>);
+    fn stream_id(&self) -> Option<&str>;
+    fn set_stream_id(&mut self, stream_id: Option<String>);
+}
+
+macro_rules! impl_stream_props {
+    ($stream_type:ty, $runtime: ty) => {
+        impl crate::StreamProperties for $stream_type {
+            type Runtime = $runtime;
+
+            fn runtime(&self) -> &$runtime {
+                &self.runtime
+            }
+
+            fn runtime_mut(&mut self) -> &mut $runtime {
+                &mut self.runtime
+            }
+        }
+
+        impl crate::StreamRuntime for $runtime {
+            fn uri(&self) -> Option<&url::Url> {
+                self.uri.as_ref()
+            }
+
+            fn set_uri(&mut self, uri: Option<url::Url>) {
+                self.uri = uri
+            }
+
+            fn udp_port(&self) -> Option<u16> {
+                self.udp_port
+            }
+
+            fn set_udp_port(&mut self, port: Option<u16>) {
+                self.udp_port = port;
+            }
+
+            fn stream_id(&self) -> Option<&str> {
+                self.stream_id.as_deref()
+            }
+
+            fn set_stream_id(&mut self, stream_id: Option<String>) {
+                self.stream_id = stream_id;
+            }
+        }
+    };
+}

--- a/pipeline/src/node_properties/stream_properties.rs
+++ b/pipeline/src/node_properties/stream_properties.rs
@@ -1,4 +1,6 @@
 pub trait StreamProperties {
+    /// The stream type, e.g "webrtc", "rtsp" etc
+    const STREAM_TYPE: &'static str;
     type Runtime: StreamRuntime;
 
     fn runtime(&self) -> &Self::Runtime;
@@ -15,8 +17,9 @@ pub trait StreamRuntime {
 }
 
 macro_rules! impl_stream_props {
-    ($stream_type:ty, $runtime: ty) => {
+    ($stream_type:ty, $runtime: ty, $type_str:literal) => {
         impl crate::StreamProperties for $stream_type {
+            const STREAM_TYPE: &'static str = $type_str;
             type Runtime = $runtime;
 
             fn runtime(&self) -> &$runtime {

--- a/pipeline/src/node_properties/stream_properties.rs
+++ b/pipeline/src/node_properties/stream_properties.rs
@@ -8,8 +8,8 @@ pub trait StreamProperties {
 }
 
 pub trait StreamRuntime {
-    fn uri(&self) -> Option<&url::Url>;
-    fn set_uri(&mut self, url: Option<url::Url>);
+    fn uri(&self) -> &url::Url;
+    fn set_uri(&mut self, url: url::Url);
     fn udp_port(&self) -> Option<u16>;
     fn set_udp_port(&mut self, port: Option<u16>);
     fn stream_id(&self) -> Option<&str>;
@@ -32,11 +32,11 @@ macro_rules! impl_stream_props {
         }
 
         impl crate::StreamRuntime for $runtime {
-            fn uri(&self) -> Option<&url::Url> {
-                self.uri.as_ref()
+            fn uri(&self) -> &url::Url {
+                &self.uri
             }
 
-            fn set_uri(&mut self, uri: Option<url::Url>) {
+            fn set_uri(&mut self, uri: url::Url) {
                 self.uri = uri
             }
 

--- a/pipeline/src/node_properties/stream_rtsp_out_properties.rs
+++ b/pipeline/src/node_properties/stream_rtsp_out_properties.rs
@@ -23,4 +23,11 @@ pub struct StreamRtspOutRuntime {
     /// Since pipeline can have multiple RTSP output streams we need to
     /// distribute ports at `lumeod` level.
     pub udp_port: Option<u16>,
+
+    /// Stream ID.
+    ///
+    /// This field is set to `Some` by API server.
+    ///
+    /// Stream ID is used by `lumeod` to add a WebRTC endpoint to webrtcstreamer service.
+    pub stream_id: Option<String>,
 }

--- a/pipeline/src/node_properties/stream_rtsp_out_properties.rs
+++ b/pipeline/src/node_properties/stream_rtsp_out_properties.rs
@@ -31,3 +31,5 @@ pub struct StreamRtspOutRuntime {
     /// Stream ID is used by `lumeod` to add a WebRTC endpoint to webrtcstreamer service.
     pub stream_id: Option<String>,
 }
+
+impl_stream_props!(StreamRtspOutProperties, StreamRtspOutRuntime);

--- a/pipeline/src/node_properties/stream_rtsp_out_properties.rs
+++ b/pipeline/src/node_properties/stream_rtsp_out_properties.rs
@@ -14,7 +14,7 @@ pub struct StreamRtspOutRuntime {
     /// This field is set to `Some` by `lumeod`.
     // TODO: this should be set by API server, more details here:
     //       https://app.clubhouse.io/lumeo/story/940/set-correct-stream-url-for-pipeline-streams-created-for-webrtc-nodes
-    pub uri: Option<Url>,
+    pub uri: Url,
 
     /// UDP port for `udpsink` element.
     ///

--- a/pipeline/src/node_properties/stream_rtsp_out_properties.rs
+++ b/pipeline/src/node_properties/stream_rtsp_out_properties.rs
@@ -32,4 +32,4 @@ pub struct StreamRtspOutRuntime {
     pub stream_id: Option<String>,
 }
 
-impl_stream_props!(StreamRtspOutProperties, StreamRtspOutRuntime);
+impl_stream_props!(StreamRtspOutProperties, StreamRtspOutRuntime, "rtsp");

--- a/pipeline/src/node_properties/stream_web_rtc_out_properties.rs
+++ b/pipeline/src/node_properties/stream_web_rtc_out_properties.rs
@@ -34,3 +34,5 @@ pub struct StreamWebRtcOutRuntime {
     /// Stream ID is used by `lumeod` to add a WebRTC endpoint to webrtcstreamer service.
     pub stream_id: Option<String>,
 }
+
+impl_stream_props!(StreamWebRtcOutProperties, StreamWebRtcOutRuntime);

--- a/pipeline/src/node_properties/stream_web_rtc_out_properties.rs
+++ b/pipeline/src/node_properties/stream_web_rtc_out_properties.rs
@@ -17,7 +17,7 @@ pub struct StreamWebRtcOutRuntime {
     /// conversion RTSP->WebRTC is made with a separate service.
     // TODO: this should be set by API server, more details here:
     //       https://app.clubhouse.io/lumeo/story/940/set-correct-stream-url-for-pipeline-streams-created-for-webrtc-nodes
-    pub uri: Option<Url>,
+    pub uri: Url,
 
     /// UDP port for `udpsink` element.
     ///

--- a/pipeline/src/node_properties/stream_web_rtc_out_properties.rs
+++ b/pipeline/src/node_properties/stream_web_rtc_out_properties.rs
@@ -35,4 +35,4 @@ pub struct StreamWebRtcOutRuntime {
     pub stream_id: Option<String>,
 }
 
-impl_stream_props!(StreamWebRtcOutProperties, StreamWebRtcOutRuntime);
+impl_stream_props!(StreamWebRtcOutProperties, StreamWebRtcOutRuntime, "webrtc");

--- a/pipeline/src/node_properties/usb_camera_properties.rs
+++ b/pipeline/src/node_properties/usb_camera_properties.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UsbCameraProperties {
+    pub source: String,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<Resolution>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -14,8 +16,6 @@ pub struct UsbCameraProperties {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UsbCameraRuntime {
     pub uri: url::Url,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source: Option<String>,
 }
 
 impl_camera_props!(UsbCameraProperties, UsbCameraRuntime);

--- a/pipeline/src/node_properties/usb_camera_properties.rs
+++ b/pipeline/src/node_properties/usb_camera_properties.rs
@@ -8,4 +8,12 @@ pub struct UsbCameraProperties {
     pub resolution: Option<Resolution>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub framerate: Option<u32>,
+    #[serde(flatten)]
+    pub runtime: UsbCameraRuntime,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UsbCameraRuntime {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }

--- a/pipeline/src/node_properties/usb_camera_properties.rs
+++ b/pipeline/src/node_properties/usb_camera_properties.rs
@@ -1,29 +1,11 @@
 use crate::resolution::Resolution;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UsbCameraProperties {
     pub uri: url::Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<Resolution>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "super::serialize_option"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub framerate: Option<u32>,
-}
-
-// We can ditch this manual Deserialize impl. after changing the properties to specific types.
-impl<'de> serde::de::Deserialize<'de> for UsbCameraProperties {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        let props = <std::collections::HashMap<String, String>>::deserialize(deserializer)?;
-        Ok(UsbCameraProperties {
-            uri: super::get_required(&props, "uri")?,
-            resolution: super::get_option(&props, "resolution")?,
-            framerate: super::get_option(&props, "framerate")?,
-        })
-    }
 }

--- a/pipeline/src/node_properties/usb_camera_properties.rs
+++ b/pipeline/src/node_properties/usb_camera_properties.rs
@@ -17,3 +17,5 @@ pub struct UsbCameraRuntime {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
 }
+
+impl_camera_props!(UsbCameraProperties, UsbCameraRuntime);

--- a/pipeline/src/node_properties/usb_camera_properties.rs
+++ b/pipeline/src/node_properties/usb_camera_properties.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UsbCameraProperties {
-    pub uri: url::Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<Resolution>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -12,8 +11,9 @@ pub struct UsbCameraProperties {
     pub runtime: UsbCameraRuntime,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UsbCameraRuntime {
+    pub uri: url::Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
 }


### PR DESCRIPTION
I started this work to be able to port the API server to make use of `pipeline` crate but ended up cleaning up quite a bit of stuff. I've tried my level best to keep the commits atomic and in a good order for review but I feel I failed to do a perfect job so apologies in advance for that.

The API is a breakage for lumeod and lumeo-gst but since they depend on specific git commits, that's not a big deal. However, the serialized format also changes with this, so we need to merge this at (around) the same time as PRs to port all 3 components (API server, lumeod and lumeo-gst).