### PR TITLE
Split events::Camera into LocalCamera and RemoteCamera

### DIFF
--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+url = { version = "2.1.1", features = ["serde"] }
+
+[dev-dependencies]
+serde_json = "1.0"


### PR DESCRIPTION
Previously there was a single `Camera` type that had fields mixed from two different camera types, now there are `LocalCamera` and `RemoteCamera` and a `Camera` enum. This way it is more strict.