### PR TITLE
Make runtime field optional for all nodes

### DIFF
--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -149,9 +149,9 @@ mod tests {
                 width: 720,
                 height: 480,
             }),
-            runtime: UsbCameraRuntime {
+            runtime: Some(UsbCameraRuntime {
                 uri: Url::from_str("file:///dev/video0").unwrap(),
-            },
+            }),
         })
     }
 
@@ -167,11 +167,11 @@ mod tests {
 
     fn stream_rtsp_out_properties() -> NodeProperties {
         NodeProperties::StreamRtspOut(StreamRtspOutProperties {
-            runtime: StreamRtspOutRuntime {
+            runtime: Some(StreamRtspOutRuntime {
                 uri: Url::from_str("rtsp://127.0.0.1:5555/mycamera").unwrap(),
                 udp_port: Some(5800),
                 stream_id: None,
-            },
+            }),
         })
     }
 }

--- a/pipeline/src/node_properties/camera_properties.rs
+++ b/pipeline/src/node_properties/camera_properties.rs
@@ -9,8 +9,8 @@ pub trait CameraProperties {
     fn set_framerate(&mut self, framerate: Option<u32>);
     fn source(&self) -> &str;
     fn set_source(&mut self, source: String);
-    fn runtime(&self) -> &Self::Runtime;
-    fn runtime_mut(&mut self) -> &mut Self::Runtime;
+    fn runtime(&self) -> Option<&Self::Runtime>;
+    fn runtime_mut(&mut self) -> Option<&mut Self::Runtime>;
 }
 
 pub trait CameraRuntime {
@@ -47,12 +47,12 @@ macro_rules! impl_camera_props {
                 self.source = source;
             }
 
-            fn runtime(&self) -> &$runtime {
-                &self.runtime
+            fn runtime(&self) -> Option<&$runtime> {
+                self.runtime.as_ref()
             }
 
-            fn runtime_mut(&mut self) -> &mut $runtime {
-                &mut self.runtime
+            fn runtime_mut(&mut self) -> Option<&mut $runtime> {
+                self.runtime.as_mut()
             }
         }
 
@@ -81,9 +81,9 @@ mod test {
     fn generic_camera_api() {
         let usb_camera = UsbCameraProperties {
             source: String::from("USB"),
-            runtime: UsbCameraRuntime {
+            runtime: Some(UsbCameraRuntime {
                 uri: Url::from_str("file:///whatever").unwrap(),
-            },
+            }),
             resolution: Some(Resolution {
                 width: 640,
                 height: 480,
@@ -108,7 +108,7 @@ mod test {
             },
         );
         assert_eq!(
-            camera.runtime().uri(),
+            camera.runtime().unwrap().uri(),
             &Url::from_str("file:///whatever").unwrap()
         );
     }

--- a/pipeline/src/node_properties/csi_camera_properties.rs
+++ b/pipeline/src/node_properties/csi_camera_properties.rs
@@ -10,7 +10,7 @@ pub struct CsiCameraProperties {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub framerate: Option<u32>,
     #[serde(flatten)]
-    pub runtime: CsiCameraRuntime,
+    pub runtime: Option<CsiCameraRuntime>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/pipeline/src/node_properties/function_properties.rs
+++ b/pipeline/src/node_properties/function_properties.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 pub struct FunctionProperties {
     pub code: String,
     #[serde(flatten)]
-    pub runtime: FunctionRuntime,
+    pub runtime: Option<FunctionRuntime>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/pipeline/src/node_properties/ip_camera_properties.rs
+++ b/pipeline/src/node_properties/ip_camera_properties.rs
@@ -10,7 +10,7 @@ pub struct IpCameraProperties {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub framerate: Option<u32>,
     #[serde(flatten)]
-    pub runtime: IpCameraRuntime,
+    pub runtime: Option<IpCameraRuntime>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/pipeline/src/node_properties/model_inference_properties.rs
+++ b/pipeline/src/node_properties/model_inference_properties.rs
@@ -6,7 +6,7 @@ pub struct ModelInferenceProperties {
     /// The ID of the inference model.
     pub model_id: Uuid,
 
-    pub runtime: ModelInferenceRuntime,
+    pub runtime: Option<ModelInferenceRuntime>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/pipeline/src/node_properties/stream_properties.rs
+++ b/pipeline/src/node_properties/stream_properties.rs
@@ -3,8 +3,8 @@ pub trait StreamProperties {
     const STREAM_TYPE: &'static str;
     type Runtime: StreamRuntime;
 
-    fn runtime(&self) -> &Self::Runtime;
-    fn runtime_mut(&mut self) -> &mut Self::Runtime;
+    fn runtime(&self) -> Option<&Self::Runtime>;
+    fn runtime_mut(&mut self) -> Option<&mut Self::Runtime>;
 }
 
 pub trait StreamRuntime {
@@ -22,12 +22,12 @@ macro_rules! impl_stream_props {
             const STREAM_TYPE: &'static str = $type_str;
             type Runtime = $runtime;
 
-            fn runtime(&self) -> &$runtime {
-                &self.runtime
+            fn runtime(&self) -> Option<&$runtime> {
+                self.runtime.as_ref()
             }
 
-            fn runtime_mut(&mut self) -> &mut $runtime {
-                &mut self.runtime
+            fn runtime_mut(&mut self) -> Option<&mut $runtime> {
+                self.runtime.as_mut()
             }
         }
 

--- a/pipeline/src/node_properties/stream_rtsp_out_properties.rs
+++ b/pipeline/src/node_properties/stream_rtsp_out_properties.rs
@@ -4,7 +4,7 @@ use url::Url;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StreamRtspOutProperties {
     #[serde(flatten)]
-    pub runtime: StreamRtspOutRuntime,
+    pub runtime: Option<StreamRtspOutRuntime>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/pipeline/src/node_properties/stream_web_rtc_out_properties.rs
+++ b/pipeline/src/node_properties/stream_web_rtc_out_properties.rs
@@ -4,7 +4,7 @@ use url::Url;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StreamWebRtcOutProperties {
     #[serde(flatten)]
-    pub runtime: StreamWebRtcOutRuntime,
+    pub runtime: Option<StreamWebRtcOutRuntime>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/pipeline/src/node_properties/usb_camera_properties.rs
+++ b/pipeline/src/node_properties/usb_camera_properties.rs
@@ -10,7 +10,7 @@ pub struct UsbCameraProperties {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub framerate: Option<u32>,
     #[serde(flatten)]
-    pub runtime: UsbCameraRuntime,
+    pub runtime: Option<UsbCameraRuntime>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
The `runtime` part of node properties is our internals and therefore it cannot be set by lumeo API user and it is impossible for the user to create a valid pipeline. So I change all `runtime` fields to `Option`s.