### PR TITLE
Change stream_id type from Option<Uuid> to Uuid

### DIFF
--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -21,6 +21,7 @@ mod tests {
     };
     use crate::{Node, NodeProperties, Pipeline, Resolution};
     use crate::{SinkPad, SourcePad, SourcePads};
+    use uuid::Uuid;
 
     #[test]
     fn pipeline_nodes_de() {
@@ -62,6 +63,7 @@ mod tests {
                     "properties": {
                         "type": "stream_rtsp_out",
                         "uri": "rtsp://127.0.0.1:5555/mycamera",
+                        "stream_id": "00000000-0000-0000-0000-000000000000",
                         "udp_port": 5800
                     },
                     "wires": {}
@@ -169,8 +171,8 @@ mod tests {
         NodeProperties::StreamRtspOut(StreamRtspOutProperties {
             runtime: Some(StreamRtspOutRuntime {
                 uri: Url::from_str("rtsp://127.0.0.1:5555/mycamera").unwrap(),
+                stream_id: Uuid::nil(),
                 udp_port: Some(5800),
-                stream_id: None,
             }),
         })
     }

--- a/pipeline/src/node_properties/ip_camera_properties.rs
+++ b/pipeline/src/node_properties/ip_camera_properties.rs
@@ -20,11 +20,10 @@ pub struct IpCameraRuntime {
 
     /// Stream ID.
     ///
-    /// This field is set to `Some` by API server.
+    /// This field is set by API server.
     ///
     /// Stream ID is used by `lumeod` to add a WebRTC endpoint to webrtcstreamer service.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stream_id: Option<Uuid>,
+    pub stream_id: Uuid,
 
     /// UDP port.
     ///

--- a/pipeline/src/node_properties/stream_properties.rs
+++ b/pipeline/src/node_properties/stream_properties.rs
@@ -14,8 +14,8 @@ pub trait StreamRuntime {
     fn set_uri(&mut self, url: url::Url);
     fn udp_port(&self) -> Option<u16>;
     fn set_udp_port(&mut self, port: Option<u16>);
-    fn stream_id(&self) -> Option<Uuid>;
-    fn set_stream_id(&mut self, stream_id: Option<Uuid>);
+    fn stream_id(&self) -> Uuid;
+    fn set_stream_id(&mut self, stream_id: Uuid);
 }
 
 macro_rules! impl_stream_props {
@@ -50,11 +50,11 @@ macro_rules! impl_stream_props {
                 self.udp_port = port;
             }
 
-            fn stream_id(&self) -> Option<uuid::Uuid> {
+            fn stream_id(&self) -> uuid::Uuid {
                 self.stream_id
             }
 
-            fn set_stream_id(&mut self, stream_id: Option<uuid::Uuid>) {
+            fn set_stream_id(&mut self, stream_id: uuid::Uuid) {
                 self.stream_id = stream_id;
             }
         }

--- a/pipeline/src/node_properties/stream_rtsp_out_properties.rs
+++ b/pipeline/src/node_properties/stream_rtsp_out_properties.rs
@@ -27,10 +27,10 @@ pub struct StreamRtspOutRuntime {
 
     /// Stream ID.
     ///
-    /// This field is set to `Some` by API server.
+    /// This field is set by API server.
     ///
     /// Stream ID is used by `lumeod` to add a WebRTC endpoint to webrtcstreamer service.
-    pub stream_id: Option<Uuid>,
+    pub stream_id: Uuid,
 }
 
 impl_stream_props!(StreamRtspOutProperties, StreamRtspOutRuntime, "rtsp");

--- a/pipeline/src/node_properties/stream_web_rtc_out_properties.rs
+++ b/pipeline/src/node_properties/stream_web_rtc_out_properties.rs
@@ -30,10 +30,10 @@ pub struct StreamWebRtcOutRuntime {
 
     /// Stream ID.
     ///
-    /// This field is set to `Some` by API server.
+    /// This field is set by API server.
     ///
     /// Stream ID is used by `lumeod` to add a WebRTC endpoint to webrtcstreamer service.
-    pub stream_id: Option<Uuid>,
+    pub stream_id: Uuid,
 }
 
 impl_stream_props!(StreamWebRtcOutProperties, StreamWebRtcOutRuntime, "webrtc");


### PR DESCRIPTION
Since `stream_id` is filled by API server there is no need to have `stream_id` optional. API server can just set `stream_id` when it sets `runtime` field to `Some`.