### PR TITLE
Add `stream_type()` getter

### DIFF
--- a/pipeline/src/node_properties/stream_properties.rs
+++ b/pipeline/src/node_properties/stream_properties.rs
@@ -7,6 +7,10 @@ pub trait StreamProperties {
 
     fn runtime(&self) -> Option<&Self::Runtime>;
     fn runtime_mut(&mut self) -> Option<&mut Self::Runtime>;
+
+    fn stream_type(&self) -> &'static str {
+        Self::STREAM_TYPE
+    }
 }
 
 pub trait StreamRuntime {


### PR DESCRIPTION
Now `STREAM_TYPE` can only be assessed as a type constant:

```rust
StreamRtspOutProperties::STREAM_TYPE
```

but it can be useful to access it as an object method:

```rust
let props: StreamRtspOutProperties;
props.stream_type();
```