### PR TITLE
Get camera with auth

### DIFF
--- a/commands/Cargo.toml
+++ b/commands/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+lumeo-events = { path = "../events" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+url = { version = "2.1.1", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde"] }
-lumeo-events = { path = "../events" }
 
 [dev-dependencies]
 uuid = { version = "0.8", features = ["v4", "serde"] }

--- a/commands/Cargo.toml
+++ b/commands/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 uuid = { version = "0.8", features = ["serde"] }
+lumeo-events = { path = "../events" }
 
 [dev-dependencies]
 uuid = { version = "0.8", features = ["v4", "serde"] }

--- a/commands/src/api/camera.rs
+++ b/commands/src/api/camera.rs
@@ -1,0 +1,12 @@
+pub use lumeo_events::camera::Camera;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum Request {
+    /// Discover cameras. Returned data can be incomplete if camera
+    /// requires authorization.
+    Discover,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DiscoverResponse(pub Vec<Camera>);

--- a/commands/src/api/camera.rs
+++ b/commands/src/api/camera.rs
@@ -1,12 +1,41 @@
 pub use lumeo_events::camera::Camera;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use url::Url;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Request {
     /// Discover cameras. Returned data can be incomplete if camera
-    /// requires authorization.
+    /// requires authorization. For authorized access use `GetWithAuth`.
     Discover,
+
+    /// Get camera information
+    GetWithAuth {
+        url: Url,
+        credentials: Option<Credentials>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiscoverResponse(pub Vec<Camera>);
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GetWithAuthResponse(pub Result<Camera, GetWithAuthError>);
+
+#[derive(Serialize, Deserialize, Debug, Clone, Error)]
+pub enum GetWithAuthError {
+    #[error("Camera is offline")]
+    CameraOffline,
+
+    #[error("Invalid credentials")]
+    InvalidCredentials,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Credentials {
+    /// Camera user name
+    pub username: String,
+
+    /// Plaintext password
+    pub password: String,
+}

--- a/commands/src/api/mod.rs
+++ b/commands/src/api/mod.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
 
+pub mod camera;
 pub mod deployment;
 pub mod webrtc;
 
@@ -49,8 +50,8 @@ pub enum Body {
     StartDeployment(deployment::StartDeployment),
     /// Stop deployment
     StopDeployment(deployment::StopDeployment),
-    /// Discover cameras
-    Discover,
+    /// Camera commands
+    Camera(camera::Request),
     /// WebRTC subcommands collection
     WebRtc(webrtc::Request),
 }


### PR DESCRIPTION
This PR adds a new request from API to lumeod: `camera::Request::GetWithAuth`. This new request allows us to get more detailed information about camera because it will use camera credentials to access protected properties if any.

Corresponding PRs:
- lumeod: https://github.com/lumeohq/lumeod/pull/44
- api: https://github.com/lumeohq/cloud-services/pull/96