### PR TITLE
pipeline: Add `transform` node

### DIFF
--- a/pipeline/src/node_properties/convert_properties.rs
+++ b/pipeline/src/node_properties/convert_properties.rs
@@ -1,9 +1,0 @@
-use serde::{Deserialize, Serialize};
-
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ConvertProperties {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fps: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resolution: Option<crate::Resolution>,
-}

--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -20,8 +20,8 @@ pub mod usb_camera_properties;
 pub use usb_camera_properties::{UsbCameraProperties, UsbCameraRuntime};
 pub mod ip_camera_properties;
 pub use ip_camera_properties::{IpCameraProperties, IpCameraRuntime};
-pub mod convert_properties;
-pub use convert_properties::ConvertProperties;
+pub mod transform_properties;
+pub use transform_properties::{FlipDirection, TransformProperties};
 pub mod model_inference_properties;
 pub use model_inference_properties::{ModelInferenceProperties, ModelInferenceRuntime};
 pub mod metadata_inserter_properties;
@@ -44,7 +44,7 @@ pub enum NodeProperties {
     #[serde(rename = "camera")]
     IpCamera(IpCameraProperties),
     Encode(EncodeProperties),
-    Convert(ConvertProperties),
+    Transform(TransformProperties),
     ModelInference(ModelInferenceProperties),
     MetadataInserter(MetadataInserterProperties),
     Overlay(OverlayProperties),

--- a/pipeline/src/node_properties/transform_properties.rs
+++ b/pipeline/src/node_properties/transform_properties.rs
@@ -1,0 +1,114 @@
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum FlipDirection {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct Crop {
+    /// Number of pixels to crop from the top.
+    pub top: usize,
+
+    /// Number of pixels to crop from the bottom.
+    pub bottom: usize,
+
+    /// Number of pixels to crop from the left.
+    pub left: usize,
+
+    /// Number of pixels to crop from the right.
+    pub right: usize,
+}
+
+impl FromStr for Crop {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.split(':').collect::<Vec<_>>()[..] {
+            [left, right, top, bottom] => {
+                match (left.parse(), right.parse(), top.parse(), bottom.parse()) {
+                    (Ok(left), Ok(right), Ok(top), Ok(bottom)) => Ok(Crop {
+                        left,
+                        right,
+                        top,
+                        bottom,
+                    }),
+                    _ => Err(format!("Failed to parse crop region string: {}", s)),
+                }
+            }
+            _ => Err(format!("Bad resolution format: {}", s)),
+        }
+    }
+}
+
+impl Serialize for Crop {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        let s = format!("{}:{}:{}:{}", self.left, self.right, self.top, self.bottom);
+
+        serializer.serialize_str(&s)
+    }
+}
+
+impl<'de> Deserialize<'de> for Crop {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let s = <&str>::deserialize(deserializer)?;
+
+        Crop::from_str(s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TransformProperties {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fps: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<crate::Resolution>,
+
+    /// Rotation angle in degrees.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rotate: Option<f64>,
+
+    /// Flip direction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flip: Option<FlipDirection>,
+
+    /// Crop region.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub crop: Option<Crop>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Crop, FlipDirection, TransformProperties};
+    use serde_json::{from_str, to_string};
+
+    #[test]
+    fn transform() {
+        let t = TransformProperties {
+            fps: Some(15),
+            resolution: Some(crate::Resolution {
+                width: 640,
+                height: 480,
+            }),
+            rotate: Some(88_f64),
+            flip: Some(FlipDirection::Vertical),
+            crop: Some(Crop {
+                top: 51,
+                bottom: 49,
+                left: 9,
+                right: 1,
+            }),
+        };
+
+        let s = to_string(&t).unwrap();
+        assert_eq!(t, from_str(&s).unwrap());
+    }
+}

--- a/pipeline/src/node_properties/transform_properties.rs
+++ b/pipeline/src/node_properties/transform_properties.rs
@@ -67,8 +67,11 @@ impl<'de> Deserialize<'de> for Crop {
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TransformProperties {
+    /// Framerate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fps: Option<u32>,
+
+    /// The desired resolution.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<crate::Resolution>,
 


### PR DESCRIPTION
Rename `convert` to `transform` and add the new properties.

Story detail: https://app.clubhouse.io/lumeo/story/1184/video-transform-node