### PR TITLE
Add CombineStreams node definition

### DIFF
--- a/pipeline/src/node_properties/combine_properties.rs
+++ b/pipeline/src/node_properties/combine_properties.rs
@@ -1,0 +1,12 @@
+//! Combine multiple streams, and interleave the frames to create one output stream.
+//! Also resizes all frames to specified output resolution.
+
+use crate::Resolution;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CombineProperties {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<Resolution>,
+    pub num_streams: u32,
+}

--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -31,6 +31,8 @@ pub mod snapshot_properties;
 pub use snapshot_properties::SnapshotProperties;
 pub mod function_properties;
 pub use function_properties::{FunctionProperties, FunctionRuntime};
+pub mod combine_properties;
+pub use combine_properties::CombineProperties;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
@@ -49,4 +51,5 @@ pub enum NodeProperties {
     #[serde(rename = "stream_webrtc_out")]
     StreamWebRtcOut(StreamWebRtcOutProperties),
     Function(FunctionProperties),
+    Combine(CombineProperties),
 }


### PR DESCRIPTION
[CombineStreams node on Notion](https://www.notion.so/PIPELINE-5c9e100b5222472883b2cb47b5eb3d4d?p=b08efbd66d984f1e9f27327dfec1166e)
[Story details](https://app.clubhouse.io/lumeo/story/1366)

<del>There's some inconsistency in naming: actual node name is "Combine Streams" but the type is just "combine".
I prefer the full name in Rust code, so I'm renaming it with `#[serde(rename = "combine")]`. Probably we'll change the type to "combine_streams" in the spec and will remove the rename.<del>