### PR TITLE
Bugfix: Save clip node doesn’t enforce max clip duration and size to split clips

### DIFF
--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_with = "1.0"
 url = { version = "2.1", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde"] }
 

--- a/pipeline/src/node_properties/clip_properties.rs
+++ b/pipeline/src/node_properties/clip_properties.rs
@@ -2,22 +2,41 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use url::Url;
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "location", rename_all = "snake_case")]
+pub enum ClipProperties {
+    Local(LocalClipProperties),
+    LumeoCloud(LumeoCloudClipProperties),
+}
+
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ClipProperties {
+pub struct CommonClipProperties {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_duration: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_duration: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_size: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retention_duration: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub webhook_url: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger: Option<String>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LocalClipProperties {
+    #[serde(flatten)]
+    pub common: CommonClipProperties,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_duration_sec: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_size_bytes: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_edge_files: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub edge_retention_duration: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cloud_upload: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cloud_retention_duration: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub webhook_url: Option<Url>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LumeoCloudClipProperties {
+    #[serde(flatten)]
+    pub common: CommonClipProperties,
 }

--- a/pipeline/src/node_properties/clip_properties.rs
+++ b/pipeline/src/node_properties/clip_properties.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::path::PathBuf;
 use url::Url;
 
@@ -9,29 +10,23 @@ pub enum ClipProperties {
     LumeoCloud(LumeoCloudClipProperties),
 }
 
+#[skip_serializing_none]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CommonClipProperties {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_duration: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_duration: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_size: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub retention_duration: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub webhook_url: Option<Url>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub trigger: Option<String>,
 }
 
+#[skip_serializing_none]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LocalClipProperties {
     #[serde(flatten)]
     pub common: CommonClipProperties,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_edge_files: Option<u64>,
 }
 

--- a/pipeline/src/node_properties/combine_properties.rs
+++ b/pipeline/src/node_properties/combine_properties.rs
@@ -3,10 +3,11 @@
 
 use crate::Resolution;
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
+#[skip_serializing_none]
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CombineProperties {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<Resolution>,
     pub num_streams: u32,
 }

--- a/pipeline/src/node_properties/encode_properties.rs
+++ b/pipeline/src/node_properties/encode_properties.rs
@@ -1,14 +1,12 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
+#[skip_serializing_none]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EncodeProperties {
     pub codec: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_bitrate: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub bitrate: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub quality: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub fps: Option<u32>,
 }

--- a/pipeline/src/node_properties/grid_properties.rs
+++ b/pipeline/src/node_properties/grid_properties.rs
@@ -1,10 +1,11 @@
 use crate::Resolution;
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
+#[skip_serializing_none]
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GridProperties {
     pub rows: u32,
     pub columns: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<Resolution>,
 }

--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -26,7 +26,9 @@ pub use metadata_inserter_properties::MetadataInserterProperties;
 pub mod overlay_properties;
 pub use overlay_properties::OverlayProperties;
 pub mod clip_properties;
-pub use clip_properties::ClipProperties;
+pub use clip_properties::{
+    ClipProperties, CommonClipProperties, LocalClipProperties, LumeoCloudClipProperties,
+};
 pub mod snapshot_properties;
 pub use snapshot_properties::SnapshotProperties;
 pub mod function_properties;

--- a/pipeline/src/node_properties/snapshot_properties.rs
+++ b/pipeline/src/node_properties/snapshot_properties.rs
@@ -1,19 +1,15 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::path::PathBuf;
 use url::Url;
 
+#[skip_serializing_none]
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SnapshotProperties {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_edge_files: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub edge_retention_duration: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cloud_upload: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cloud_retention_duration: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub webhook_url: Option<Url>,
 }

--- a/pipeline/src/node_properties/transform_properties.rs
+++ b/pipeline/src/node_properties/transform_properties.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -65,26 +66,22 @@ impl<'de> Deserialize<'de> for Crop {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TransformProperties {
     /// Framerate.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub fps: Option<u32>,
 
     /// The desired resolution.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<crate::Resolution>,
 
     /// Rotation angle in degrees.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub rotate: Option<f64>,
 
     /// Flip direction.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub flip: Option<FlipDirection>,
 
     /// Crop region.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub crop: Option<Crop>,
 }
 

--- a/pipeline/src/node_properties/video_source_properties.rs
+++ b/pipeline/src/node_properties/video_source_properties.rs
@@ -1,5 +1,6 @@
 use crate::resolution::Resolution;
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use url::Url;
 use uuid::Uuid;
 
@@ -10,6 +11,7 @@ pub enum VideoSourceProperties {
     Stream(InputStreamProperties),
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CommonVideoSourceProperties {
     /// ID of associated object.
@@ -19,12 +21,10 @@ pub struct CommonVideoSourceProperties {
 
     /// Resolution of video source.
     /// If unset then some reasonable default is used.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub resolution: Option<Resolution>,
 
     /// Framerate of video source.
     /// If unset then some reasonable default is used.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub framerate: Option<u32>,
 }
 


### PR DESCRIPTION
This PR updates `Clip` node fields according to the [latest spec](https://www.notion.so/PIPELINE-5c9e100b5222472883b2cb47b5eb3d4d?p=8db951f3477e4bb0b728a920832dc1dd).

Story details: https://app.clubhouse.io/lumeo/story/1444