### PR TITLE
Add camera::Request::GetLocal

### DIFF
--- a/commands/src/api/camera.rs
+++ b/commands/src/api/camera.rs
@@ -1,4 +1,4 @@
-pub use lumeo_events::camera::Camera;
+pub use lumeo_events::camera::{Camera, LocalCamera};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
@@ -8,6 +8,9 @@ pub enum Request {
     /// Discover cameras. Returned data can be incomplete if camera
     /// requires authorization. For authorized access use `GetWithAuth`.
     Discover,
+
+    /// Get local camera information
+    GetLocal { url: Url },
 
     /// Get camera information
     GetWithAuth {
@@ -20,7 +23,16 @@ pub enum Request {
 pub struct DiscoverResponse(pub Vec<Camera>);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GetLocalResponse(pub Result<LocalCamera, GetLocalError>);
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GetWithAuthResponse(pub Result<Camera, GetWithAuthError>);
+
+#[derive(Serialize, Deserialize, Debug, Clone, Error)]
+pub enum GetLocalError {
+    #[error("Camera is offline")]
+    CameraOffline,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, Error)]
 pub enum GetWithAuthError {


### PR DESCRIPTION
USB Camera capabilities (format, resolution, frame rate) should be populated in the camera properties when Camera is Linked. To make this happen I add a new command in this PR: `camera::Request::GetLocal`.

Related PRs:
- api: https://github.com/lumeohq/cloud-services/pull/183
- lumeod: https://github.com/lumeohq/lumeod/pull/77

Story details: https://app.clubhouse.io/lumeo/story/1460