### PR TITLE
Support both "fps" and "framerate" for relevant nodes

### DIFF
--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -168,7 +168,7 @@ mod tests {
             max_bitrate: Some(1_500_000),
             bitrate: None,
             quality: Some(10),
-            fps: Some(15),
+            framerate: Some(15),
         })
     }
 

--- a/pipeline/src/node_properties/encode_properties.rs
+++ b/pipeline/src/node_properties/encode_properties.rs
@@ -8,5 +8,6 @@ pub struct EncodeProperties {
     pub max_bitrate: Option<u32>,
     pub bitrate: Option<u32>,
     pub quality: Option<u32>,
-    pub fps: Option<u32>,
+    #[serde(alias = "fps")]
+    pub framerate: Option<u32>,
 }

--- a/pipeline/src/node_properties/transform_properties.rs
+++ b/pipeline/src/node_properties/transform_properties.rs
@@ -70,7 +70,8 @@ impl<'de> Deserialize<'de> for Crop {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TransformProperties {
     /// Framerate.
-    pub fps: Option<u32>,
+    #[serde(alias = "fps")]
+    pub framerate: Option<u32>,
 
     /// The desired resolution.
     pub resolution: Option<crate::Resolution>,
@@ -93,7 +94,7 @@ mod test {
     #[test]
     fn transform() {
         let t = TransformProperties {
-            fps: Some(15),
+            framerate: Some(15),
             resolution: Some(crate::Resolution {
                 width: 640,
                 height: 480,

--- a/pipeline/src/node_properties/video_source_properties.rs
+++ b/pipeline/src/node_properties/video_source_properties.rs
@@ -25,6 +25,7 @@ pub struct CommonVideoSourceProperties {
 
     /// Framerate of video source.
     /// If unset then some reasonable default is used.
+    #[serde(alias = "fps")]
     pub framerate: Option<u32>,
 }
 


### PR DESCRIPTION
Story details: https://app.clubhouse.io/lumeo/story/1693

Turns out it's not just video sources (that is what EncodeProperties is for, right?), but also transform. I've applied the same change to both.