### PR TITLE
Add gateway online/offline events

### DIFF
--- a/events/src/gateway.rs
+++ b/events/src/gateway.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum Event {
+    Online { version: String },
+    Offline,
+}

--- a/events/src/lib.rs
+++ b/events/src/lib.rs
@@ -2,9 +2,11 @@ use serde::{Deserialize, Serialize};
 
 pub mod camera;
 pub mod deployment;
+pub mod gateway;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Event {
+    Gateway(gateway::Event),
     Deployment(deployment::Event),
     Camera(camera::Event),
 }


### PR DESCRIPTION
Currently `lumeod` sends it's offline/online status in some uncommon format. So the plan is to change it to JSON just like all other events. To achieve it I add a (de)serializable `gateway::Event` type here.