### PR TITLE
Change ModelInferenceRuntime's infer_node_unique_ids property to an option

### DIFF
--- a/pipeline/src/node_properties/model_inference_properties.rs
+++ b/pipeline/src/node_properties/model_inference_properties.rs
@@ -37,5 +37,5 @@ pub struct ModelInferenceRuntime {
     /// Inferencing Gstreamer element requires a unique numerical id for itself
     /// and for any other inferencing nodes it operates on.
     /// Map key is pipeline node id, val is unique id assigned to it at runtime.
-    pub infer_node_unique_ids: HashMap<String, i32>,
+    pub infer_node_unique_ids: Option<HashMap<String, i32>>,
 }


### PR DESCRIPTION
.. to fix deserialization issue.

Essentially, the following code panics with props == ModelInference because infer_node_unique_ids isn't present when the pipeline is first deserialized: 
```
                let runtime = props.runtime.as_mut().context("'runtime' is missing")?;
```
This is because ModelInferenceRuntime.infer_node_unique_ids is not sent in from the server, but populated / computed in lumeod.