### PR TITLE
Add VideoSource::common::source_name

### DIFF
--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -36,7 +36,8 @@ mod tests {
                         "framerate": 15,
                         "resolution": "720x480",
                         "usb": {
-                            "uri": "file:///dev/video0"
+                            "uri": "file:///dev/video0",
+                            "name": "Qwerty 3000",
                         }
                     },
                     "wires": {
@@ -158,6 +159,7 @@ mod tests {
             },
             runtime: Some(CameraRuntime::Usb(UsbCameraRuntime {
                 uri: Url::from_str("file:///dev/video0").unwrap(),
+                name: "Qwerty 3000".to_string(),
             })),
         }))
     }

--- a/pipeline/src/node_properties/video_source_properties.rs
+++ b/pipeline/src/node_properties/video_source_properties.rs
@@ -65,6 +65,9 @@ pub struct UsbCameraRuntime {
     ///
     /// Example: "file:///dev/video0"
     pub uri: Url,
+
+    /// Camera name.
+    pub name: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -73,6 +76,9 @@ pub struct CsiCameraRuntime {
     ///
     /// Example: "file:///dev/video0"
     pub uri: Url,
+
+    /// Camera name.
+    pub name: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -81,6 +87,9 @@ pub struct InputRtspStreamRuntime {
     ///
     /// Example: "rtsp://192.168.0.42:554/hd_stream"
     pub uri: Url,
+
+    /// Stream name.
+    pub name: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Story details: https://app.clubhouse.io/lumeo/story/1730/video-source-node-should-insert-metadata