### PR TITLE
events: Add GstError event

### DIFF
--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 url = { version = "2.1.1", features = ["serde"] }
+zvariant = "2.4.0"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/events/src/deployment.rs
+++ b/events/src/deployment.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use zvariant::derive::Type;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Event {
@@ -13,4 +14,21 @@ pub enum DeploymentEventKind {
     Stopped,
     StopFailed,
     ExitedUnexpectedly,
+    GstError(GstError),
+}
+
+#[derive(Serialize, Deserialize, Type, Debug, Clone)]
+pub enum GstErrorDomain {
+    Core = 1,
+    Library = 2,
+    Resource = 3,
+    Stream = 4,
+}
+
+#[derive(Serialize, Deserialize, Type, Debug, Clone)]
+pub struct GstError {
+    pub domain: GstErrorDomain,
+    // FIXME: We probaly could do better than this and use an enum here.
+    pub code: i32,
+    pub description: String,
 }


### PR DESCRIPTION
This will be used to send gstreamer errors from lumeod to the web services.

Related story: https://app.clubhouse.io/lumeo/story/2203/lumeod-reports-error-codes-description-along-with-error-events-to-backend