### PR TITLE
events: Add a node log message event

### DIFF
--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 url = { version = "2.1.1", features = ["serde"] }
-zvariant = "2.4.0"
+zvariant = { version = "2.4.0", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/events/src/deployment.rs
+++ b/events/src/deployment.rs
@@ -15,6 +15,7 @@ pub enum DeploymentEventKind {
     StopFailed,
     ExitedUnexpectedly,
     GstError(GstError),
+    NodeLog(NodeLog),
 }
 
 #[derive(Serialize, Deserialize, Type, Debug, Clone)]
@@ -31,4 +32,11 @@ pub struct GstError {
     // FIXME: We probaly could do better than this and use an enum here.
     pub code: i32,
     pub description: String,
+}
+
+#[derive(Serialize, Deserialize, Type, Debug, Clone)]
+pub struct NodeLog {
+    // ID of the source node.
+    pub source: Option<String>,
+    pub msg: String,
 }

--- a/events/src/deployment.rs
+++ b/events/src/deployment.rs
@@ -36,7 +36,7 @@ pub struct GstError {
 
 #[derive(Serialize, Deserialize, Type, Debug, Clone)]
 pub struct NodeLog {
-    // ID of the source node.
-    pub source: Option<String>,
+    // ID of the source node. Enable it when we've means to set it.
+    //pub source: String,
     pub msg: String,
 }


### PR DESCRIPTION
This will be used to send log messages from all the way from gst runner to our MQTT through lumeod.