### PR TITLE
Fix transform_properties::Crop deserialization

### DIFF
--- a/pipeline/src/node_properties/transform_properties.rs
+++ b/pipeline/src/node_properties/transform_properties.rs
@@ -60,9 +60,9 @@ impl<'de> Deserialize<'de> for Crop {
     where
         D: serde::de::Deserializer<'de>,
     {
-        let s = <&str>::deserialize(deserializer)?;
+        let s = String::deserialize(deserializer)?;
 
-        Crop::from_str(s).map_err(serde::de::Error::custom)
+        Crop::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
 


### PR DESCRIPTION
Story details: https://app.clubhouse.io/lumeo/story/3491

I have no idea why `&str` doesn't work in our case. 

A relevant part of JSON: `{"type":"transform","crop_region":"0:280:256:0"}`.
Here, `0:280:256:0` can be easily extracted without allocating a new `String` :shrug: 

Useful comment: https://github.com/serde-rs/serde/issues/1413#issuecomment-494892266