### PR TITLE
Add Demultiplex streams node

### DIFF
--- a/pipeline/src/node_properties/demultiplex_properties.rs
+++ b/pipeline/src/node_properties/demultiplex_properties.rs
@@ -1,0 +1,4 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DemultiplexProperties {}

--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -2,71 +2,72 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod clip_properties;
+pub mod combine_properties;
+pub mod encode_properties;
+pub mod function_properties;
+pub mod grid_properties;
+pub mod gst_template_properties;
+pub mod metadata_inserter_properties;
+pub mod model_inference_properties;
+pub mod overlay_properties;
+pub mod snapshot_properties;
+#[macro_use]
+pub mod stream_properties;
+pub mod stream_rtsp_out_properties;
+pub mod stream_web_rtc_out_properties;
+pub mod track_properties;
+pub mod transform_properties;
 pub mod video_source_properties;
+
+pub use clip_properties::{
+    ClipProperties, CommonClipProperties, LocalClipProperties, LumeoCloudClipProperties,
+};
+pub use combine_properties::CombineProperties;
+pub use encode_properties::EncodeProperties;
+pub use function_properties::{FunctionProperties, FunctionRuntime};
+pub use grid_properties::GridProperties;
+pub use gst_template_properties::GstTemplateProperties;
+pub use metadata_inserter_properties::MetadataInserterProperties;
+pub use model_inference_properties::{
+    ClassInferenceProperties, ModelInferenceProperties, ModelInferenceRuntime,
+};
+pub use overlay_properties::OverlayProperties;
+pub use snapshot_properties::{
+    CommonSnapshotProperties, LocalSnapshotProperties, LumeoCloudSnapshotProperties,
+    SnapshotProperties,
+};
+pub use stream_properties::{StreamProperties, StreamRuntime};
+pub use stream_rtsp_out_properties::{StreamRtspOutProperties, StreamRtspOutRuntime};
+pub use stream_web_rtc_out_properties::{StreamWebRtcOutProperties, StreamWebRtcOutRuntime};
+pub use track_properties::{TrackProperties, Tracker, TrackerProfile};
+pub use transform_properties::{FlipDirection, TransformProperties};
 pub use video_source_properties::{
     CameraProperties, CameraRuntime, CommonVideoSourceProperties, InputRtspStreamRuntime,
     InputStreamProperties, InputStreamRuntime, InputWebRtcStreamRuntime, RotateDirection,
     UsbCameraRuntime, VideoSourceProperties,
 };
-#[macro_use]
-pub mod stream_properties;
-pub use stream_properties::{StreamProperties, StreamRuntime};
-pub mod encode_properties;
-pub use encode_properties::EncodeProperties;
-pub mod gst_template_properties;
-pub use gst_template_properties::GstTemplateProperties;
-pub mod stream_rtsp_out_properties;
-pub use stream_rtsp_out_properties::{StreamRtspOutProperties, StreamRtspOutRuntime};
-pub mod stream_web_rtc_out_properties;
-pub use stream_web_rtc_out_properties::{StreamWebRtcOutProperties, StreamWebRtcOutRuntime};
-pub mod transform_properties;
-pub use transform_properties::{FlipDirection, TransformProperties};
-pub mod model_inference_properties;
-pub use model_inference_properties::{
-    ClassInferenceProperties, ModelInferenceProperties, ModelInferenceRuntime,
-};
-pub mod metadata_inserter_properties;
-pub use metadata_inserter_properties::MetadataInserterProperties;
-pub mod overlay_properties;
-pub use overlay_properties::OverlayProperties;
-pub mod clip_properties;
-pub use clip_properties::{
-    ClipProperties, CommonClipProperties, LocalClipProperties, LumeoCloudClipProperties,
-};
-pub mod snapshot_properties;
-pub use snapshot_properties::{
-    CommonSnapshotProperties, LocalSnapshotProperties, LumeoCloudSnapshotProperties,
-    SnapshotProperties,
-};
-pub mod track_properties;
-pub use track_properties::{TrackProperties, Tracker, TrackerProfile};
-pub mod function_properties;
-pub use function_properties::{FunctionProperties, FunctionRuntime};
-pub mod combine_properties;
-pub use combine_properties::CombineProperties;
-pub mod grid_properties;
-pub use grid_properties::GridProperties;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum NodeProperties {
-    #[serde(rename = "video")]
-    VideoSource(VideoSourceProperties),
+    Clip(ClipProperties),
+    Combine(CombineProperties),
     Encode(EncodeProperties),
-    Transform(TransformProperties),
-    ModelInference(ModelInferenceProperties),
+    Function(FunctionProperties),
+    Grid(GridProperties),
+    GstTemplate(GstTemplateProperties),
     #[serde(rename = "metadata_add")]
     MetadataInserter(MetadataInserterProperties),
+    ModelInference(ModelInferenceProperties),
     Overlay(OverlayProperties),
-    Clip(ClipProperties),
     Snapshot(SnapshotProperties),
     StreamRtspOut(StreamRtspOutProperties),
     #[serde(rename = "stream_webrtc_out")]
     StreamWebRtcOut(StreamWebRtcOutProperties),
     Track(TrackProperties),
-    Function(FunctionProperties),
-    GstTemplate(GstTemplateProperties),
-    Combine(CombineProperties),
-    Grid(GridProperties),
+    Transform(TransformProperties),
+    #[serde(rename = "video")]
+    VideoSource(VideoSourceProperties),
 }

--- a/pipeline/src/node_properties/mod.rs
+++ b/pipeline/src/node_properties/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod clip_properties;
 pub mod combine_properties;
+pub mod demultiplex_properties;
 pub mod encode_properties;
 pub mod function_properties;
 pub mod grid_properties;
@@ -24,6 +25,7 @@ pub use clip_properties::{
     ClipProperties, CommonClipProperties, LocalClipProperties, LumeoCloudClipProperties,
 };
 pub use combine_properties::CombineProperties;
+pub use demultiplex_properties::DemultiplexProperties;
 pub use encode_properties::EncodeProperties;
 pub use function_properties::{FunctionProperties, FunctionRuntime};
 pub use grid_properties::GridProperties;
@@ -54,6 +56,7 @@ pub use video_source_properties::{
 pub enum NodeProperties {
     Clip(ClipProperties),
     Combine(CombineProperties),
+    Demultiplex(DemultiplexProperties),
     Encode(EncodeProperties),
     Function(FunctionProperties),
     Grid(GridProperties),


### PR DESCRIPTION
Apparently there are no interesting properties to be set on `nvstreamdemux`, so for now I will leave the struct empty (just like happens on the Overlay node)

```
$ gst-inspect-1.0 nvstreamdemux
Factory Details:
  Rank                     primary (256)
  Long-name                Stream demultiplexer
  Klass                    Generic
  Description              1-to-N pipes stream demultiplexing
  Author                   NVIDIA Corporation. Post on Deepstream for Tesla forum for any queries @ https://devtalk.nvidia.com/default/board/209/

Plugin Details:
  Name                     nvdsgst_multistream
  Description              NVIDIA Multistream mux/demux plugin
  Filename                 /usr/lib/aarch64-linux-gnu/gstreamer-1.0/deepstream/libnvdsgst_multistream.so
  Version                  5.0.1
  License                  Proprietary
  Source module            nvmultistream
  Binary package           NVIDIA Multistream Plugins
  Origin URL               http://nvidia.com/

GObject
 +----GInitiallyUnowned
       +----GstObject
             +----GstElement
                   +----GstNvStreamDemux

Pad Templates:
  SINK template: 'sink'
    Availability: Always
    Capabilities:
      video/x-raw(memory:NVMM)
                 format: { (string)NV12, (string)RGBA }
                  width: [ 1, 2147483647 ]
                 height: [ 1, 2147483647 ]
              framerate: [ 0/1, 2147483647/1 ]
  
  SRC template: 'src_%u'
    Availability: On request
    Capabilities:
      video/x-raw(memory:NVMM)
                 format: { (string)NV12, (string)RGBA }
                  width: [ 1, 2147483647 ]
                 height: [ 1, 2147483647 ]
              framerate: [ 0/1, 2147483647/1 ]

Element has no clocking capabilities.
Element has no URI handling capabilities.

Pads:
  SINK: 'sink'
    Pad Template: 'sink'

Element Properties:
  name                : The name of the object
                        flags: readable, writable
                        String. Default: "nvstreamdemux0"
  parent              : The parent of the object
                        flags: readable, writable
                        Object of type "GstObject"
```
