### PR TITLE
Upgrade zvariant

### DIFF
--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 serde = { version = "1.0", features = ["derive"] }
 url = { version = "2.1.1", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde"] }
-zvariant = { version = "2.7.0", default-features = false }
+zvariant = { version = "2.8.0", default-features = false }


### PR DESCRIPTION
Trying to fix this error:
```
error[E0161]: cannot move a value of type owned_value::OwnedValue: the size of owned_value::OwnedValue cannot be statically determined
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/zvariant-2.8.0/src/value.rs:174:21
    |
174 |                 let o = OwnedValue::from(&**v);
    |                     ^

error[E0161]: cannot move a value of type owned_value::OwnedValue: the size of owned_value::OwnedValue cannot be statically determined
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/zvariant-2.8.0/src/value.rs:175:39
    |
175 |                 Value::Value(Box::new(o.into_inner()))
    |                                       ^

error[E0161]: cannot move a value of type owned_value::OwnedValue: the size of owned_value::OwnedValue cannot be statically determined
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/zvariant-2.8.0/src/owned_value.rs:197:9
    |
197 |         v.into_inner()
    |         ^

error[E0161]: cannot move a value of type owned_value::OwnedValue: the size of owned_value::OwnedValue cannot be statically determined
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/zvariant-2.8.0/src/owned_value.rs:214:12
    |
214 |         Ok(Value::deserialize(deserializer)?.into())
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```