### PR TITLE
Add `camera::Request::UpdateDetails` command 

### DIFF
--- a/commands/src/api/camera.rs
+++ b/commands/src/api/camera.rs
@@ -11,9 +11,6 @@ pub enum Request {
     CreateStreams { camera_id: Uuid },
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiscoverResponse(pub Vec<Camera>);
-
 /// `Camera` type represents different camera types.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "conn_type", rename_all = "snake_case")]

--- a/commands/src/api/camera.rs
+++ b/commands/src/api/camera.rs
@@ -9,6 +9,9 @@ pub enum Request {
 
     /// Create camera streams
     CreateStreams { camera_id: Uuid },
+
+    /// Fetch camera details from physical camera and update the camera
+    UpdateDetails { camera_id: Uuid },
 }
 
 /// `Camera` type represents different camera types.

--- a/commands/src/api/camera.rs
+++ b/commands/src/api/camera.rs
@@ -118,6 +118,7 @@ pub struct Fraction {
 pub enum Status {
     Online,
     Offline,
+    Unauthorized,
 }
 
 /// Local camera interface.


### PR DESCRIPTION
So that lumeod could update details on demand. This is needed when the camera was added manually and is lacking some details that are usually collected upon discovery.